### PR TITLE
Avalonia.Svg: Implemented clipping using simple objects

### DIFF
--- a/src/Avalonia.Svg/AvaloniaModelExtensions.cs
+++ b/src/Avalonia.Svg/AvaloniaModelExtensions.cs
@@ -769,10 +769,4 @@ public static class AvaloniaModelExtensions
 
         return streamGeometry;
     }
-
-    public static AM.Geometry? ToGeometry(this ClipPath clipPath, bool isFilled)
-    {
-        // TODO: clipPath
-        return null;
-    }
 }

--- a/src/Avalonia.Svg/Commands/RoundedClipDrawCommand.cs
+++ b/src/Avalonia.Svg/Commands/RoundedClipDrawCommand.cs
@@ -1,0 +1,13 @@
+﻿using A = Avalonia;
+
+namespace Avalonia.Svg.Commands;
+
+public sealed class RoundedClipDrawCommand : DrawCommand
+{
+    public A.RoundedRect Clip { get; }
+
+    public RoundedClipDrawCommand(A.RoundedRect clip)
+    {
+        Clip = clip;
+    }
+}


### PR DESCRIPTION
I have implemented basic ClipPathCanvasCommand handling in Avalonia.Svg with Rect, RoundedRect, Circle, and Ellipse. Avalonia currently doesn't have a DrawingContext.PushGeometryClip(IGeometryImpl), so I can't use the Factory.

Tested on Linux.

(I discovered Avalonia.Svg.Skia after writing this and it appears to handle clipping fine... Is that package recommended over Avalonia.Svg?)

Test asset:
![ClipTest](https://user-images.githubusercontent.com/553741/196012168-e0750569-8554-4ef5-b3a3-6ce5b4cf8d54.svg)

Before and after these changes:
![Change](https://user-images.githubusercontent.com/553741/196012395-f53f81bb-3297-428a-a643-aa37a7101b2d.png)
