### PR TITLE
Fix build for latest Avalonia sources

### DIFF
--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.ReactiveUI.props
+++ b/build/Avalonia.ReactiveUI.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Skia.props
+++ b/build/Avalonia.Skia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Skia" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Skia" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview7" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Web.props
+++ b/build/Avalonia.Web.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Browser" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0034141-beta" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Controls.Skia/SKBitmapDrawOperation.cs
+++ b/src/Avalonia.Controls.Skia/SKBitmapDrawOperation.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using SkiaSharp;
@@ -26,9 +27,9 @@ public class SKBitmapDrawOperation : ICustomDrawOperation
 
     public bool Equals(ICustomDrawOperation? other) => false;
 
-    public void Render(IDrawingContextImpl context)
+    public void Render(ImmediateDrawingContext context)
     {
-        var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+        var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
         if (leaseFeature is null)
         {
             return;

--- a/src/Avalonia.Controls.Skia/SKCanvasDrawOperation.cs
+++ b/src/Avalonia.Controls.Skia/SKCanvasDrawOperation.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
@@ -55,9 +57,9 @@ public class SKCanvasDrawOperation : ICustomDrawOperation
     /// 
     /// </summary>
     /// <param name="context"></param>
-    public void Render(IDrawingContextImpl context)
+    public void Render(ImmediateDrawingContext context)
     {
-        var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+        var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
         if (leaseFeature is null)
         {
             return;

--- a/src/Avalonia.Controls.Skia/SKPathDrawOperation.cs
+++ b/src/Avalonia.Controls.Skia/SKPathDrawOperation.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using SkiaSharp;
@@ -28,9 +29,9 @@ public class SKPathDrawOperation : ICustomDrawOperation
 
     public bool Equals(ICustomDrawOperation? other) => false;
 
-    public void Render(IDrawingContextImpl context)
+    public void Render(ImmediateDrawingContext context)
     {
-        var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+        var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
         if (leaseFeature is null)
         {
             return;

--- a/src/Avalonia.Controls.Skia/SKPictureDrawOperation.cs
+++ b/src/Avalonia.Controls.Skia/SKPictureDrawOperation.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using SkiaSharp;
@@ -26,9 +27,9 @@ public class SKPictureDrawOperation : ICustomDrawOperation
 
     public bool Equals(ICustomDrawOperation? other) => false;
 
-    public void Render(IDrawingContextImpl context)
+    public void Render(ImmediateDrawingContext context)
     {
-        var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+        var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
         if (leaseFeature is null)
         {
             return;

--- a/src/Avalonia.Svg.Skia/SvgCustomDrawOperation.cs
+++ b/src/Avalonia.Svg.Skia/SvgCustomDrawOperation.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Svg.Skia;
@@ -25,14 +26,14 @@ public class SvgCustomDrawOperation : ICustomDrawOperation
 
     public bool Equals(ICustomDrawOperation? other) => false;
 
-    public void Render(IDrawingContextImpl context)
+    public void Render(ImmediateDrawingContext context)
     {
         if (_svg?.Picture is null)
         {
             return;
         }
         
-        var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+        var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
         if (leaseFeature is null)
         {
             return;

--- a/tests/Avalonia.Svg.Skia.UnitTests/SvgImageTests.cs
+++ b/tests/Avalonia.Svg.Skia.UnitTests/SvgImageTests.cs
@@ -10,7 +10,7 @@ public class SvgImageTests
     public void SvgImage_Load()
     {
         var uri = new Uri($"avares://Avalonia.Svg.Skia.UnitTests/Assets/Icon.svg");
-        var assetLoader = new AssetLoader(); // AvaloniaLocator.Current.GetService<IAssetLoader>()
+        var assetLoader = new StandardAssetLoader(); // AvaloniaLocator.Current.GetService<IAssetLoader>()
 
         var svgFile = assetLoader.Open(uri);
         Assert.NotNull(svgFile);


### PR DESCRIPTION
In the latest Avalonia sources:
- The `ICustomDrawOperation` changed the interface from `Render(IDrawingContextImpl)` to `Render(ImmediateDrawingContext)`.
- The AssetLoader class was made static, and now the StandardAssetLoader needs to be used for unit testing.

Applied the needed changes to make it compile again.

Fixes #157 