### PR TITLE
Fix image draw

### DIFF
--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.ReactiveUI.props
+++ b/build/Avalonia.ReactiveUI.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Skia.props
+++ b/build/Avalonia.Skia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Skia" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Skia" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0034141-beta" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Web.props
+++ b/build/Avalonia.Web.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia.Browser" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0034141-beta" />
+    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0034282-beta" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Controls.Skia/SKBitmapImage.cs
+++ b/src/Avalonia.Controls.Skia/SKBitmapImage.cs
@@ -33,7 +33,7 @@ public class SKBitmapImage : AvaloniaObject, IImage, IAffectsRender
     public Size Size => Source is { } ? new Size(Source.Width, Source.Height) : default;
 
     /// <inheritdoc/>
-    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode)
+    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect)
     {
         var source = Source;
         if (source is null)

--- a/src/Avalonia.Controls.Skia/SKPathImage.cs
+++ b/src/Avalonia.Controls.Skia/SKPathImage.cs
@@ -48,7 +48,7 @@ public class SKPathImage : AvaloniaObject, IImage, IAffectsRender
     public Size Size => Source is { } ? new Size(Source.Bounds.Width, Source.Bounds.Height) : default;
 
     /// <inheritdoc/>
-    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode)
+    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect)
     {
         var source = Source;
         if (source is null)

--- a/src/Avalonia.Controls.Skia/SKPictureImage.cs
+++ b/src/Avalonia.Controls.Skia/SKPictureImage.cs
@@ -33,7 +33,7 @@ public class SKPictureImage : AvaloniaObject, IImage, IAffectsRender
     public Size Size => Source is { } ? new Size(Source.CullRect.Width, Source.CullRect.Height) : default;
 
     /// <inheritdoc/>
-    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode)
+    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect)
     {
         var source = Source;
         if (source is null)

--- a/src/Avalonia.Svg.Skia/SvgImage.cs
+++ b/src/Avalonia.Svg.Skia/SvgImage.cs
@@ -34,10 +34,7 @@ public class SvgImage : AvaloniaObject, IImage, IAffectsRender
         Source?.Picture is { } ? new Size(Source.Picture.CullRect.Width, Source.Picture.CullRect.Height) : default;
 
     /// <inheritdoc/>
-    void IImage.Draw(
-        DrawingContext context,
-        Rect sourceRect,
-        Rect destRect)
+    void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect)
     {
         var source = Source;
         if (source?.Picture is null)

--- a/src/Avalonia.Svg.Skia/SvgImage.cs
+++ b/src/Avalonia.Svg.Skia/SvgImage.cs
@@ -37,8 +37,7 @@ public class SvgImage : AvaloniaObject, IImage, IAffectsRender
     void IImage.Draw(
         DrawingContext context,
         Rect sourceRect,
-        Rect destRect,
-        BitmapInterpolationMode bitmapInterpolationMode)
+        Rect destRect)
     {
         var source = Source;
         if (source?.Picture is null)


### PR DESCRIPTION
After updating to `11.0.999-cibuild0034141-beta`, the `IImage.Draw` interface changed. This PR fixes that.