### PR TITLE
Update Avalonia version to preview8

### DIFF
--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.ReactiveUI.props
+++ b/build/Avalonia.ReactiveUI.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Skia.props
+++ b/build/Avalonia.Skia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Skia" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Skia" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0034282-beta" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview8" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Web.props
+++ b/build/Avalonia.Web.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia.Browser" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0034282-beta" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update the Avalonia version to the official `preview8` packages.

@wieslawsoltes please could you generate official nuget packages for this? Thanks!