### PR TITLE
Add major roll forward policy for dotnet tool

### DIFF
--- a/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
+++ b/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
@@ -11,6 +11,7 @@
     <PackAsTool>True</PackAsTool>
     <ToolCommandName>Svg.Skia.Converter</ToolCommandName>
     <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Closes #164.

I see that you've already bumped the runtime version to .NET 7 (fine by me), but for the future, it would still be a good idea to have this roll forward setting.

This change leads to adding of `"rollForward": "Major"` to the `runtimeconfig.json`.