### PR TITLE
Attempt at a fix for #195

### DIFF
--- a/src/Svg.Model/SvgExtensions.Painting.cs
+++ b/src/Svg.Model/SvgExtensions.Painting.cs
@@ -795,15 +795,25 @@ public static partial class SvgExtensions
         {
             case SvgColourServer svgColourServer:
                 {
+                    // We don't need to use a shader if we're just drawing a solid coloir in sRGB
+                    // See issue #195
                     var skColor = GetColor(svgColourServer, opacity, ignoreAttributes);
                     var colorInterpolation = GetColorInterpolation(svgVisualElement);
                     var isLinearRgb = colorInterpolation == SvgColourInterpolation.LinearRGB;
-                    var skColorSpace = isLinearRgb ? SKColorSpace.SrgbLinear : SKColorSpace.Srgb;
-                    var skColorShader = SKShader.CreateColor(skColor, skColorSpace);
-                    if (skColorShader is { })
+                    if (!isLinearRgb)
                     {
-                        skPaint.Shader = skColorShader;
+                        skPaint.Color = skColor;
                         return true;
+                    }
+                    else
+                    {
+                        // Fall back to a shader which lets us specify the colour space
+                        var skColorShader = SKShader.CreateColor(skColor, SKColorSpace.SrgbLinear);
+                        if (skColorShader is { })
+                        {
+                            skPaint.Shader = skColorShader;
+                            return true;
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
This _seems_ to work locally for me, and ensures we make a sensibly sized PDF if we choose to render the `SKPicture` to PDF. Very happy to make changes if you have any suggestions.

Note that for non standard sRGB (linear) I _think_ we have no choice but to fall-back to a shader and rasterise. I'm not convinced, for the PDF backend anyway, that Skia actually has support for any other colour models.

For the happy path though, this seems to conclusively solve the problems I was having with a basic/simple SVG (with no e.g. `color-interpolation` attributes set anywhere). I've tested with some different fill colours locally (red, yellow etc) and it seems to function as I'd expect.

As an aside, I really hope you will be able to keep this library under a permissive license. The current license is why I am happy to work with this library, try and dig into bugs myself and open this PR.

I know it's not easy (the SVG spec itself is enormous and what is implemented here is genuinely impressive), and maintaining OSS libraries is often a thankless job and often not one that nets much financial support, but it would genuinely be a shame for another library in this space to adopt a more restrictive license.