### PR TITLE
GetDimensions precision

### DIFF
--- a/src/Svg.Model/SvgExtensions.Transforms.cs
+++ b/src/Svg.Model/SvgExtensions.Transforms.cs
@@ -178,7 +178,7 @@ public static partial class SvgExtensions
             h = svgFragment.Height.ToDeviceValue(UnitRenderingType.Vertical, svgFragment, SKRect.Empty);
         }
 
-        return new SKSize((float)Math.Round(w), (float)Math.Round(h));
+        return new SKSize((float)Math.Round(w, 3), (float)Math.Round(h, 3));
     }
 
     internal static SKMatrix ToMatrix(this SvgMatrix svgMatrix)


### PR DESCRIPTION
Implementation of #179...

Round SvgExtensions.Transforms.GetDimensions return value to three decimal places. Otherwise, non-integer viewbox dimensions lose precision. This can cause subtle left/top shifts in raster output.

The standard data type for viewbox dimensions is a "number" and can be decimal:
https://developer.mozilla.org/en-US/docs/Web/SVG/Content_type#number

SKSize members and all relevant local variables are floats so this should cause no issues. The only unsure part is whether "3" is too arbitrary; a very large ViewBox could have four significant integer figures so a case could be made for "4" instead.
