### PR TITLE
Add ShimSkiaSharp unit tests

### DIFF
--- a/tests/ShimSkiaSharp.UnitTests/SKCanvasTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKCanvasTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKCanvasTests
+{
+    private static SKCanvas CreateCanvas()
+    {
+        var recorder = new SKPictureRecorder();
+        return recorder.BeginRecording(SKRect.Create(0,0,10,10));
+    }
+
+    [Fact]
+    public void SetMatrix_AddsCommandAndUpdatesMatrix()
+    {
+        var canvas = CreateCanvas();
+        var delta = SKMatrix.CreateTranslation(5,5);
+        canvas.SetMatrix(delta);
+        Assert.Equal(delta, canvas.TotalMatrix);
+        var cmd = Assert.IsType<SetMatrixCanvasCommand>(canvas.Commands!.Single());
+        Assert.Equal(delta, cmd.DeltaMatrix);
+        Assert.Equal(delta, cmd.TotalMatrix);
+    }
+
+    [Fact]
+    public void SaveAndRestore_RecordCommands()
+    {
+        var canvas = CreateCanvas();
+        var count = canvas.Save();
+        Assert.Equal(1, count);
+        canvas.Restore();
+        Assert.Equal(2, canvas.Commands!.Count);
+        var save = Assert.IsType<SaveCanvasCommand>(canvas.Commands![0]);
+        Assert.Equal(0, save.Count);
+        var restore = Assert.IsType<RestoreCanvasCommand>(canvas.Commands![1]);
+        Assert.Equal(0, restore.Count);
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKPathTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKPathTests.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKPathTests
+{
+    [Fact]
+    public void NewPath_IsEmpty()
+    {
+        var path = new SKPath();
+        Assert.True(path.IsEmpty);
+        Assert.Empty(path.Commands);
+        Assert.Equal(SKRect.Empty, path.Bounds);
+    }
+
+    [Fact]
+    public void AddRect_AddsCommandAndUpdatesBounds()
+    {
+        var rect = SKRect.Create(0, 0, 10, 20);
+        var path = new SKPath();
+        path.AddRect(rect);
+        Assert.False(path.IsEmpty);
+        Assert.Single(path.Commands);
+        var cmd = Assert.IsType<AddRectPathCommand>(path.Commands.First());
+        Assert.Equal(rect, cmd.Rect);
+        Assert.Equal(rect, path.Bounds);
+    }
+
+    [Fact]
+    public void MoveTo_LineTo_UpdatesBounds()
+    {
+        var path = new SKPath();
+        path.MoveTo(1, 2);
+        path.LineTo(3, 4);
+        Assert.Equal(new SKRect(1,2,3,4), path.Bounds);
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKPictureRecorderTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKPictureRecorderTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKPictureRecorderTests
+{
+    [Fact]
+    public void BeginAndEndRecording_Works()
+    {
+        var recorder = new SKPictureRecorder();
+        var rect = SKRect.Create(0, 0, 10, 10);
+        var canvas = recorder.BeginRecording(rect);
+        Assert.NotNull(canvas);
+        Assert.Equal(SKMatrix.Identity, canvas.TotalMatrix);
+        canvas.Save();
+
+        var picture = recorder.EndRecording();
+        Assert.Equal(rect, picture.CullRect);
+        Assert.NotNull(picture.Commands);
+        Assert.Single(picture.Commands);
+        Assert.IsType<SaveCanvasCommand>(picture.Commands![0]);
+        Assert.Equal(SKRect.Empty, recorder.CullRect);
+        Assert.Null(recorder.RecordingCanvas);
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKRectTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKRectTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKRectTests
+{
+    [Fact]
+    public void Create_Works()
+    {
+        var rect = SKRect.Create(5, 7, 10, 20);
+        Assert.Equal(5, rect.Left);
+        Assert.Equal(7, rect.Top);
+        Assert.Equal(15, rect.Right);
+        Assert.Equal(27, rect.Bottom);
+        Assert.Equal(10, rect.Width);
+        Assert.Equal(20, rect.Height);
+    }
+
+    [Fact]
+    public void Contains_Point_Works()
+    {
+        var rect = SKRect.Create(0, 0, 10, 10);
+        Assert.True(rect.Contains(new SKPoint(5,5)));
+        Assert.False(rect.Contains(new SKPoint(20,20)));
+    }
+
+    [Fact]
+    public void Contains_Rect_Works()
+    {
+        var outer = SKRect.Create(0, 0, 10, 10);
+        var inner = SKRect.Create(2, 2, 5, 5);
+        Assert.True(outer.Contains(inner));
+        Assert.False(inner.Contains(outer));
+    }
+
+    [Fact]
+    public void Union_Works()
+    {
+        var a = SKRect.Create(0,0,10,10);
+        var b = SKRect.Create(5,5,10,10);
+        var u = SKRect.Union(a,b);
+        Assert.Equal(0, u.Left);
+        Assert.Equal(0, u.Top);
+        Assert.Equal(15, u.Right);
+        Assert.Equal(15, u.Bottom);
+    }
+
+    [Fact]
+    public void ToString_ReturnsExpected()
+    {
+        var rect = SKRect.Create(1,2,5,5);
+        Assert.Equal("1, 2, 5, 5", rect.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- test `SKRect` helper methods and operators
- test `SKPath` command handling
- test `SKPictureRecorder` begin/end logic
- test `SKCanvas` matrix and save/restore operations

## Testing
- `dotnet test tests/ShimSkiaSharp.UnitTests/ShimSkiaSharp.UnitTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68741dae3f4c8321a5bcbad0a030c3ce