### PR TITLE
Add ShimSkiaSharp unit tests

### DIFF
--- a/tests/ShimSkiaSharp.UnitTests/SKColorFTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKColorFTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKColorFTests
+{
+    [Fact]
+    public void Implicit_To_SKColor_Works()
+    {
+        var colorF = new SKColorF(0.5f, 0.25f, 0.75f, 0.4f);
+        SKColor color = colorF;
+        Assert.Equal((byte)(0.5f * 255f), color.Red);
+        Assert.Equal((byte)(0.25f * 255f), color.Green);
+        Assert.Equal((byte)(0.75f * 255f), color.Blue);
+        Assert.Equal((byte)(0.4f * 255f), color.Alpha);
+    }
+
+    [Fact]
+    public void ToString_Returns_CommaSeparatedValues()
+    {
+        var colorF = new SKColorF(1f, 0.5f, 0.25f, 0f);
+        Assert.Equal("1, 0.5, 0.25, 0", colorF.ToString());
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKColorTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKColorTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKColorTests
+{
+    [Fact]
+    public void Implicit_To_SKColorF_Works()
+    {
+        var color = new SKColor(255, 128, 64, 32);
+        SKColorF colorF = color;
+        Assert.Equal(1f, colorF.Red, 6);
+        Assert.Equal(128f / 255f, colorF.Green, 6);
+        Assert.Equal(64f / 255f, colorF.Blue, 6);
+        Assert.Equal(32f / 255f, colorF.Alpha, 6);
+    }
+
+    [Fact]
+    public void ToString_Returns_CommaSeparatedValues()
+    {
+        var color = new SKColor(1, 2, 3, 4);
+        Assert.Equal("1, 2, 3, 4", color.ToString());
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKDrawableTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKDrawableTests.cs
@@ -1,0 +1,39 @@
+using Xunit;
+using ShimSkiaSharp;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKDrawableTests
+{
+    private class TestDrawable : SKDrawable
+    {
+        public int DrawCalls { get; private set; }
+        protected override void OnDraw(SKCanvas canvas)
+        {
+            DrawCalls++;
+            canvas.Save();
+        }
+        protected override SKRect OnGetBounds() => SKRect.Create(1, 2, 3, 4);
+    }
+
+    [Fact]
+    public void Snapshot_Uses_OnGetBounds()
+    {
+        var drawable = new TestDrawable();
+        var picture = drawable.Snapshot();
+        Assert.Equal(SKRect.Create(1, 2, 3, 4), picture.CullRect);
+        Assert.Equal(1, drawable.DrawCalls);
+        Assert.Single(picture.Commands!);
+        Assert.IsType<SaveCanvasCommand>(picture.Commands![0]);
+    }
+
+    [Fact]
+    public void Snapshot_WithBounds_UsesProvidedBounds()
+    {
+        var drawable = new TestDrawable();
+        var bounds = SKRect.Create(10, 10, 5, 5);
+        var picture = drawable.Snapshot(bounds);
+        Assert.Equal(bounds, picture.CullRect);
+        Assert.Equal(1, drawable.DrawCalls);
+    }
+}

--- a/tests/ShimSkiaSharp.UnitTests/SKImageTests.cs
+++ b/tests/ShimSkiaSharp.UnitTests/SKImageTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using ShimSkiaSharp;
+using System.IO;
+
+namespace ShimSkiaSharp.UnitTests;
+
+public class SKImageTests
+{
+    [Fact]
+    public void FromStream_ReadsAllBytes()
+    {
+        var data = new byte[] { 1, 2, 3, 4, 5 };
+        using var ms = new MemoryStream(data);
+        var result = SKImage.FromStream(ms);
+        Assert.Equal(data, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add missing tests for `SKColor`, `SKColorF`, `SKDrawable`, and `SKImage`

## Testing
- `dotnet test tests/ShimSkiaSharp.UnitTests/ShimSkiaSharp.UnitTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68741e8954108321a053429bd2523660