### PR TITLE
Add OnDraw event and update test app drawing logic

### DIFF
--- a/samples/TestApp/Views/MainView.axaml.cs
+++ b/samples/TestApp/Views/MainView.axaml.cs
@@ -7,8 +7,12 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using ShimSkiaSharp;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia;
+using Svg.Skia;
+using Svg.Model.Drawables;
+using Svg.Model.Services;
 using TestApp.ViewModels;
 
 namespace TestApp.Views;
@@ -16,6 +20,7 @@ namespace TestApp.Views;
 public partial class MainView : UserControl
 {
     private readonly ObservableCollection<string> _hitResults = new();
+    private SKSvg? _currentSkSvg;
 
     public MainView()
     {
@@ -23,6 +28,22 @@ public partial class MainView : UserControl
         AddHandler(DragDrop.DropEvent, Drop);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         HitResults.ItemsSource = _hitResults;
+        SubscribeOnDraw();
+    }
+
+    private void SubscribeOnDraw()
+    {
+        if (_currentSkSvg is { })
+        {
+            _currentSkSvg.OnDraw -= SkSvg_OnDraw;
+        }
+
+        _currentSkSvg = Svg.SkSvg;
+
+        if (_currentSkSvg is { })
+        {
+            _currentSkSvg.OnDraw += SkSvg_OnDraw;
+        }
     }
 
     private void DragOver(object? sender, DragEventArgs e)
@@ -82,6 +103,7 @@ public partial class MainView : UserControl
         if (svg is { })
         {
             svg.Settings.ShowHitBounds = ShowHitBoundsToggle.IsChecked == true;
+            SubscribeOnDraw();
             Svg.InvalidateVisual();
         }
     }
@@ -112,6 +134,7 @@ public partial class MainView : UserControl
             }
         }
 
+        SubscribeOnDraw();
         Svg.InvalidateVisual();
     }
 
@@ -123,8 +146,59 @@ public partial class MainView : UserControl
         {
             skSvg.Settings.HitTestPoints.Clear();
             skSvg.Settings.ShowHitBounds = ShowHitBoundsToggle.IsChecked == true;
+            SubscribeOnDraw();
         }
 
         Svg.InvalidateVisual();
+    }
+
+    private void SkSvg_OnDraw(object? sender, SKSvgDrawEventArgs e)
+    {
+        if (sender is not SKSvg skSvg || skSvg.Drawable is not DrawableBase drawable)
+        {
+            return;
+        }
+
+        if (!skSvg.Settings.ShowHitBounds)
+        {
+            return;
+        }
+
+        var hits = new HashSet<DrawableBase>();
+
+        if (skSvg.Settings.HitTestPoints is { })
+        {
+            foreach (var pt in skSvg.Settings.HitTestPoints)
+            {
+                foreach (var d in HitTestService.HitTest(drawable, pt))
+                {
+                    hits.Add(d);
+                }
+            }
+        }
+
+        if (skSvg.Settings.HitTestRects is { })
+        {
+            foreach (var r in skSvg.Settings.HitTestRects)
+            {
+                foreach (var d in HitTestService.HitTest(drawable, r))
+                {
+                    hits.Add(d);
+                }
+            }
+        }
+
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            Color = skSvg.Settings.HitBoundsColor
+        };
+
+        foreach (var hit in hits.Take(1))
+        {
+            var rect = skSvg.SkiaModel.ToSKRect(hit.TransformedBounds);
+            e.Canvas.DrawRect(rect, paint);
+        }
     }
 }

--- a/samples/TestApp/Views/MainView.axaml.cs
+++ b/samples/TestApp/Views/MainView.axaml.cs
@@ -1,15 +1,12 @@
 ﻿using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using ShimSkiaSharp;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia;
 using Svg.Skia;
 using Svg.Model.Drawables;
 using Svg.Model.Services;
@@ -188,12 +185,10 @@ public partial class MainView : UserControl
             }
         }
 
-        using var paint = new SKPaint
-        {
-            IsAntialias = true,
-            Style = SKPaintStyle.Stroke,
-            Color = skSvg.Settings.HitBoundsColor
-        };
+        using var paint = new SkiaSharp.SKPaint();
+        paint.IsAntialias = true;
+        paint.Style = SkiaSharp.SKPaintStyle.Stroke;
+        paint.Color = skSvg.Settings.HitBoundsColor;
 
         foreach (var hit in hits.Take(1))
         {

--- a/src/Svg.Skia/SKSvg.Model.cs
+++ b/src/Svg.Skia/SKSvg.Model.cs
@@ -102,6 +102,13 @@ public partial class SKSvg : IDisposable
 
     public virtual SkiaSharp.SKPicture? Picture { get; protected set; }
 
+    public event EventHandler<SKSvgDrawEventArgs>? OnDraw;
+
+    protected virtual void RaiseOnDraw(SKSvgDrawEventArgs e)
+    {
+        OnDraw?.Invoke(this, e);
+    }
+
     public SvgParameters? Parameters => _originalParameters;
 
     public SKSvg()
@@ -263,45 +270,7 @@ public partial class SKSvg : IDisposable
 
         canvas.DrawPicture(Picture);
 
-        if (Settings.ShowHitBounds && Drawable is DrawableBase drawable)
-        {
-            var hits = new HashSet<DrawableBase>();
-
-            if (Settings.HitTestPoints is { })
-            {
-                foreach (var pt in Settings.HitTestPoints)
-                {
-                    foreach (var d in HitTestService.HitTest(drawable, pt))
-                    {
-                        hits.Add(d);
-                    }
-                }
-            }
-
-            if (Settings.HitTestRects is { })
-            {
-                foreach (var r in Settings.HitTestRects)
-                {
-                    foreach (var d in HitTestService.HitTest(drawable, r))
-                    {
-                        hits.Add(d);
-                    }
-                }
-            }
-
-            using var paint = new SkiaSharp.SKPaint
-            {
-                IsAntialias = true,
-                Style = SkiaSharp.SKPaintStyle.Stroke,
-                Color = Settings.HitBoundsColor
-            };
-
-            foreach (var hit in hits.Take(1))
-            {
-                var rect = SkiaModel.ToSKRect(hit.TransformedBounds);
-                canvas.DrawRect(rect, paint);
-            }
-        }
+        RaiseOnDraw(new SKSvgDrawEventArgs(canvas));
     }
 
     private void Reset()

--- a/src/Svg.Skia/SKSvgDrawEventArgs.cs
+++ b/src/Svg.Skia/SKSvgDrawEventArgs.cs
@@ -1,13 +1,12 @@
 using System;
-using ShimSkiaSharp;
 
 namespace Svg.Skia;
 
 public class SKSvgDrawEventArgs : EventArgs
 {
-    public SKCanvas Canvas { get; }
+    public SkiaSharp.SKCanvas Canvas { get; }
 
-    internal SKSvgDrawEventArgs(SKCanvas canvas)
+    internal SKSvgDrawEventArgs(SkiaSharp.SKCanvas canvas)
     {
         Canvas = canvas;
     }

--- a/src/Svg.Skia/SKSvgDrawEventArgs.cs
+++ b/src/Svg.Skia/SKSvgDrawEventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+using ShimSkiaSharp;
+
+namespace Svg.Skia;
+
+public class SKSvgDrawEventArgs : EventArgs
+{
+    public SKCanvas Canvas { get; }
+
+    internal SKSvgDrawEventArgs(SKCanvas canvas)
+    {
+        Canvas = canvas;
+    }
+}


### PR DESCRIPTION
## Summary
- add `SKSvgDrawEventArgs` for canvas callbacks
- expose `OnDraw` event in `SKSvg` and remove built-in hit bounds drawing
- subscribe to `OnDraw` in `TestApp` and draw hit test bounds there

## Testing
- `dotnet build Svg.Skia.sln -v q` *(fails: .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68742266d6b48321825b28eb653554ce