### PR TITLE
Remove hit test fields from SKSvgSettings

### DIFF
--- a/src/Svg.Skia/SKSvgSettings.cs
+++ b/src/Svg.Skia/SKSvgSettings.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
 using Svg.Skia.TypefaceProviders;
-using ShimSkiaSharp;
 
 namespace Svg.Skia;
 
@@ -18,13 +17,6 @@ public class SKSvgSettings
 
     public IList<ITypefaceProvider>? TypefaceProviders  { get; set; }
 
-    public bool ShowHitBounds { get; set; }
-
-    public SkiaSharp.SKColor HitBoundsColor { get; set; }
-
-    public IList<ShimSkiaSharp.SKPoint> HitTestPoints { get; set; }
-
-    public IList<ShimSkiaSharp.SKRect> HitTestRects { get; set; }
 
     public SKSvgSettings()
     {
@@ -41,10 +33,5 @@ public class SKSvgSettings
             new FontManagerTypefaceProvider(),
             new DefaultTypefaceProvider()
         };
-
-        ShowHitBounds = false;
-        HitBoundsColor = SkiaSharp.SKColors.Cyan;
-        HitTestPoints = new List<ShimSkiaSharp.SKPoint>();
-        HitTestRects = new List<ShimSkiaSharp.SKRect>();
     }
 }


### PR DESCRIPTION
## Summary
- remove hit bounds fields from `SKSvgSettings`
- manage hit bound state directly in `MainView`

## Testing
- `dotnet test -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687425d1b20083219a425d9115f7539a