### PR TITLE
Fix translation matrix orientation

### DIFF
--- a/src/Skia.Controls.Avalonia/SKBitmapControl.cs
+++ b/src/Skia.Controls.Avalonia/SKBitmapControl.cs
@@ -116,8 +116,8 @@ public class SKBitmapControl : Control
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
 
         if (bounds.IsEmpty || destRect == default)
         {

--- a/src/Skia.Controls.Avalonia/SKBitmapImage.cs
+++ b/src/Skia.Controls.Avalonia/SKBitmapImage.cs
@@ -46,7 +46,7 @@ public class SKBitmapImage : AvaloniaObject, IImage
         }
         var bounds = SKRect.Create(0, 0, source.Width, source.Height);
         var scaleMatrix = Matrix.CreateScale(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
-        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Top, -sourceRect.Y + destRect.Y - bounds.Left);
+        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Left, -sourceRect.Y + destRect.Y - bounds.Top);
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))
         {

--- a/src/Skia.Controls.Avalonia/SKPathControl.cs
+++ b/src/Skia.Controls.Avalonia/SKPathControl.cs
@@ -133,8 +133,8 @@ public class SKPathControl : Control
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
 
         if (bounds.IsEmpty || destRect == default)
         {

--- a/src/Skia.Controls.Avalonia/SKPathImage.cs
+++ b/src/Skia.Controls.Avalonia/SKPathImage.cs
@@ -66,7 +66,7 @@ public class SKPathImage : AvaloniaObject, IImage
             return;
         }
         var scaleMatrix = Matrix.CreateScale(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
-        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Top, -sourceRect.Y + destRect.Y - bounds.Left);
+        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Left, -sourceRect.Y + destRect.Y - bounds.Top);
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))
         {

--- a/src/Skia.Controls.Avalonia/SKPictureControl.cs
+++ b/src/Skia.Controls.Avalonia/SKPictureControl.cs
@@ -116,8 +116,8 @@ public class SKPictureControl : Control
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
 
         if (bounds.IsEmpty || destRect == default)
         {

--- a/src/Skia.Controls.Avalonia/SKPictureImage.cs
+++ b/src/Skia.Controls.Avalonia/SKPictureImage.cs
@@ -46,7 +46,7 @@ public class SKPictureImage : AvaloniaObject, IImage
             return;
         }
         var scaleMatrix = Matrix.CreateScale(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
-        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Top, -sourceRect.Y + destRect.Y - bounds.Left);
+        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Left, -sourceRect.Y + destRect.Y - bounds.Top);
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))
         {

--- a/src/Svg.Controls.Avalonia/Svg.cs
+++ b/src/Svg.Controls.Avalonia/Svg.cs
@@ -213,8 +213,8 @@ public class Svg : Control
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
 
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))

--- a/src/Svg.Controls.Avalonia/SvgImage.cs
+++ b/src/Svg.Controls.Avalonia/SvgImage.cs
@@ -68,8 +68,8 @@ public class SvgImage : AvaloniaObject, IImage
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))
         {

--- a/src/Svg.Controls.Skia.Avalonia/Svg.cs
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.cs
@@ -149,7 +149,7 @@ public class Svg : Control
         var sourceRect = new Rect(sourceSize).CenterRect(new Rect(destRect.Size / scale));
         var bounds = picture.CullRect;
         var scaleMatrix = Matrix.CreateScale(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
-        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Top, -sourceRect.Y + destRect.Y - bounds.Left);
+        var translateMatrix = Matrix.CreateTranslation(-sourceRect.X + destRect.X - bounds.Left, -sourceRect.Y + destRect.Y - bounds.Top);
         var matrix = scaleMatrix * translateMatrix;
         var inverse = matrix.Invert();
         var local = inverse.Transform(point);
@@ -284,8 +284,8 @@ public class Svg : Control
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
 
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))

--- a/src/Svg.Controls.Skia.Avalonia/SvgImage.cs
+++ b/src/Svg.Controls.Skia.Avalonia/SvgImage.cs
@@ -87,8 +87,8 @@ public class SvgImage : AvaloniaObject, IImage
             destRect.Width / sourceRect.Width,
             destRect.Height / sourceRect.Height);
         var translateMatrix = Matrix.CreateTranslation(
-            -sourceRect.X + destRect.X - bounds.Top,
-            -sourceRect.Y + destRect.Y - bounds.Left);
+            -sourceRect.X + destRect.X - bounds.Left,
+            -sourceRect.Y + destRect.Y - bounds.Top);
         using (context.PushClip(destRect))
         using (context.PushTransform(scaleMatrix * translateMatrix))
         {


### PR DESCRIPTION
## Summary
- fix the argument order when creating translation matrices in several controls

## Testing
- `dotnet restore`
- `dotnet test --no-build` *(fails: The argument <assembly>.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6874c2691d8c83218867178415867c09