### PR TITLE
Fix arc hit test expectation

### DIFF
--- a/tests/Svg.Skia.UnitTests/HitTestTests.cs
+++ b/tests/Svg.Skia.UnitTests/HitTestTests.cs
@@ -89,7 +89,7 @@ public class HitTestTests : SvgUnitTest
         var svg = new SKSvg();
         using var _ = svg.Load(GetSvgPath("HitTestArc.svg"));
 
-        var results = svg.HitTestElements(new SKPoint(50, 70)).Select(e => e.ID).ToList();
+        var results = svg.HitTestElements(new SKPoint(50, 30)).Select(e => e.ID).ToList();
         Assert.Contains("arc", results);
     }
 }


### PR DESCRIPTION
## Summary
- adjust arc hit test to select a point inside its bounding box

## Testing
- `dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj --no-build -c Release` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cdd2cca48321ba172c25341d324d