### PR TITLE
Add text path conversion

### DIFF
--- a/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
@@ -173,4 +173,10 @@ public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
         bounds = new SKRect(0, -ascent, width, descent);
         return width;
     }
+
+    /// <inheritdoc />
+    public SKPath? GetTextPath(string? text, SKPaint paint, float x, float y)
+    {
+        return null;
+    }
 }

--- a/src/Svg.Model/Drawables/Elements/TextDrawable.cs
+++ b/src/Svg.Model/Drawables/Elements/TextDrawable.cs
@@ -18,6 +18,8 @@ public sealed class TextDrawable : DrawableBase
 
     public SKRect OwnerBounds { get; set; }
 
+    public SKPath? Path { get; private set; }
+
     private TextDrawable(ISvgAssetLoader assetLoader, HashSet<Uri>? references)
         : base(assetLoader, references)
     {
@@ -87,6 +89,7 @@ public sealed class TextDrawable : DrawableBase
         var width = AssetLoader.MeasureText(text, paint, ref bounds);
 
         GeometryBounds = new SKRect(x, y + metricsAscent, x + width, y + metricsDescent);
+        Path = AssetLoader.GetTextPath(text, paint, x, y);
         Transform = TransformsService.ToMatrix(Text.Transforms);
     }
 

--- a/src/Svg.Model/ISvgAssetLoader.cs
+++ b/src/Svg.Model/ISvgAssetLoader.cs
@@ -14,4 +14,5 @@ public interface ISvgAssetLoader
     List<TypefaceSpan> FindTypefaces(string? text, SKPaint paintPreferredTypeface);
     SKFontMetrics GetFontMetrics(SKPaint paint);
     float MeasureText(string? text, SKPaint paint, ref SKRect bounds);
+    SKPath? GetTextPath(string? text, SKPaint paint, float x, float y);
 }

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -151,4 +151,17 @@ public class SkiaSvgAssetLoader : Model.ISvgAssetLoader
         bounds = new ShimSkiaSharp.SKRect(skBounds.Left, skBounds.Top, skBounds.Right, skBounds.Bottom);
         return width;
     }
+
+    /// <inheritdoc />
+    public ShimSkiaSharp.SKPath? GetTextPath(string? text, ShimSkiaSharp.SKPaint paint, float x, float y)
+    {
+        using var skPaint = _skiaModel.ToSKPaint(paint);
+        if (skPaint is null || text is null)
+        {
+            return null;
+        }
+
+        using var skPath = skPaint.GetTextPath(text, x, y);
+        return _skiaModel.FromSKPath(skPath);
+    }
 }

--- a/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
+++ b/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
@@ -57,4 +57,9 @@ public class SkiaGeneratorSvgAssetLoader : Model.ISvgAssetLoader
         bounds = new ShimSkiaSharp.SKRect(0, -size * 0.8f, width, size * 0.2f);
         return width;
     }
+
+    public ShimSkiaSharp.SKPath? GetTextPath(string? text, ShimSkiaSharp.SKPaint paint, float x, float y)
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
## Summary
- expose `GetTextPath` on `ISvgAssetLoader`
- implement text path generation for Skia loader
- stub method for Avalonia and generator asset loaders
- convert SkiaSharp paths back into shim paths
- store generated path in `TextDrawable`

## Testing
- `dotnet test ./tests/ShimSkiaSharp.UnitTests/ShimSkiaSharp.UnitTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687577fa9a3c83218d49d50d69d5fc87