### PR TITLE
Fix SvgService bounds

### DIFF
--- a/src/Svg.Model/Services/SvgService.cs
+++ b/src/Svg.Model/Services/SvgService.cs
@@ -565,7 +565,8 @@ public static class SvgService
             }
             else
             {
-                // TODO: Calculate correct bounds using Children bounds.
+                var b = svgFragment.Bounds;
+                bounds = new SKRect(b.Left, b.Top, b.Right, b.Bottom);
             }
         }
 


### PR DESCRIPTION
## Summary
- compute child bounds when fragment has no viewBox

## Testing
- `dotnet test --no-build` *(fails: .NET SDK 9.0.100 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68760ae031e083219ba4a809979eada6