### PR TITLE
Implement Avalonia control sample

### DIFF
--- a/samples/AvaloniaControlsSample/MainWindow.axaml
+++ b/samples/AvaloniaControlsSample/MainWindow.axaml
@@ -14,13 +14,19 @@
       </Panel>
     </TabItem>
     <TabItem Header="Bitmap">
-      <!-- TODO: -->
+      <Panel Background="WhiteSmoke" Width="400" Height="400">
+        <SKBitmapControl Name="BitmapControl" Stretch="Uniform" />
+      </Panel>
     </TabItem>
     <TabItem Header="Path">
-      <!-- TODO: -->
+      <Panel Background="WhiteSmoke" Width="400" Height="400">
+        <SKPathControl Name="PathControl" Stretch="Uniform" />
+      </Panel>
     </TabItem>
     <TabItem Header="Picture">
-      <!-- TODO: -->
+      <Panel Background="WhiteSmoke" Width="400" Height="400">
+        <SKPictureControl Name="PictureControl" Stretch="Uniform" />
+      </Panel>
     </TabItem>
   </TabControl>
 </Window>

--- a/samples/AvaloniaControlsSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaControlsSample/MainWindow.axaml.cs
@@ -16,5 +16,34 @@ public partial class MainWindow : Window
         {
             e.Canvas.DrawRect(SKRect.Create(0f, 0f, 100f, 100f), new SKPaint { Color = SKColors.Aqua });
         };
+
+        // initialize bitmap control
+        var bitmap = new SKBitmap(100, 100);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.Red, IsAntialias = true };
+            canvas.DrawCircle(50, 50, 40, paint);
+        }
+        BitmapControl.Bitmap = bitmap;
+
+        // initialize path control
+        var path = new SKPath();
+        path.MoveTo(10, 10);
+        path.LineTo(90, 10);
+        path.LineTo(50, 90);
+        path.Close();
+        PathControl.Path = path;
+        PathControl.Paint = new SKPaint { Color = SKColors.Green, IsAntialias = true, Style = SKPaintStyle.Fill };
+
+        // initialize picture control
+        var recorder = new SKPictureRecorder();
+        var pictureCanvas = recorder.BeginRecording(new SKRect(0, 0, 100, 100));
+        using (var paint = new SKPaint { Color = SKColors.Blue, Style = SKPaintStyle.Stroke, StrokeWidth = 5, IsAntialias = true })
+        {
+            pictureCanvas.DrawRect(new SKRect(10, 10, 90, 90), paint);
+        }
+        var picture = recorder.EndRecording();
+        PictureControl.Picture = picture;
     }
 }

--- a/samples/AvaloniaControlsSample/Program.cs
+++ b/samples/AvaloniaControlsSample/Program.cs
@@ -13,6 +13,9 @@ internal class Program
     public static AppBuilder BuildAvaloniaApp()
     {
         GC.KeepAlive(typeof(SKCanvasControl).Assembly);
+        GC.KeepAlive(typeof(SKBitmapControl).Assembly);
+        GC.KeepAlive(typeof(SKPathControl).Assembly);
+        GC.KeepAlive(typeof(SKPictureControl).Assembly);
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .With(new X11PlatformOptions


### PR DESCRIPTION
## Summary
- show how to use all Skia.Controls.Avalonia controls
- create demo shapes for each control
- ensure assemblies stay referenced

## Testing
- `dotnet build samples/AvaloniaControlsSample/AvaloniaControlsSample.csproj -c Release` *(fails: .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68760d650fb08321875e7435f83abecc