### PR TITLE
Add wireframe mode

### DIFF
--- a/samples/TestApp/Views/MainView.axaml
+++ b/samples/TestApp/Views/MainView.axaml
@@ -143,6 +143,10 @@
                       OffContent="Hide Bounds"
                       Margin="6,0,6,0"
                       Click="ShowHitBoundsToggle_OnToggled" />
+        <ToggleSwitch IsChecked="{Binding #Svg.Wireframe}"
+                      OnContent="Wireframe On"
+                      OffContent="Wireframe Off"
+                      Margin="6,0,6,0" />
         <Button Content="Export"
                 Command="{Binding ExportCommand}"
                 CommandParameter="{Binding #Svg}"

--- a/src/Svg.Controls.Skia.Avalonia/Svg.cs
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.cs
@@ -24,6 +24,7 @@ public class Svg : Control
     private readonly Uri _baseUri;
     private SvgSource? _svg;
     private bool _enableCache;
+    private bool _wireframe;
     private Dictionary<string, SvgSource>? _cache;
 
     /// <summary>
@@ -59,6 +60,14 @@ public class Svg : Control
         AvaloniaProperty.RegisterDirect<Svg, bool>(nameof(EnableCache),
             o => o.EnableCache,
             (o, v) => o.EnableCache = v);
+
+    /// <summary>
+    /// Defines the <see cref="Wireframe"/> property.
+    /// </summary>
+    public static readonly DirectProperty<Svg, bool> WireframeProperty =
+        AvaloniaProperty.RegisterDirect<Svg, bool>(nameof(Wireframe),
+            o => o.Wireframe,
+            (o, v) => o.Wireframe = v);
 
     /// <summary>
     /// Defines the Css property.
@@ -116,6 +125,15 @@ public class Svg : Control
     {
         get { return _enableCache; }
         set { SetAndRaise(EnableCacheProperty, ref _enableCache, value); }
+    }
+
+    /// <summary>
+    /// Gets or sets a value controlling wireframe rendering mode.
+    /// </summary>
+    public bool Wireframe
+    {
+        get { return _wireframe; }
+        set { SetAndRaise(WireframeProperty, ref _wireframe, value); }
     }
 
     /// <summary>
@@ -374,6 +392,15 @@ public class Svg : Control
                 _cache = new Dictionary<string, SvgSource>();
             }
         }
+
+        if (change.Property == WireframeProperty)
+        {
+            if (_svg?.Svg is { } skSvg)
+            {
+                skSvg.Wireframe = change.GetNewValue<bool>();
+            }
+            InvalidateVisual();
+        }
     }
 
     private void LoadFromPath(string? path, SvgParameters? parameters = null)
@@ -389,6 +416,10 @@ public class Svg : Control
         if (_enableCache && _cache is { } && _cache.TryGetValue(path, out var svg))
         {
             _svg = svg;
+            if (_svg.Svg is { } skSvg)
+            {
+                skSvg.Wireframe = _wireframe;
+            }
             return;
         }
 
@@ -401,6 +432,10 @@ public class Svg : Control
         try
         {
             _svg = SvgSource.Load(path, _baseUri, parameters);
+            if (_svg?.Svg is { } skSvg2)
+            {
+                skSvg2.Wireframe = _wireframe;
+            }
 
             if (_enableCache && _cache is { } && _svg is { })
             {
@@ -429,6 +464,10 @@ public class Svg : Control
             var bytes = Encoding.UTF8.GetBytes(source);
             using var ms = new MemoryStream(bytes);
             _svg = SvgSource.LoadFromStream(ms, parameters);
+            if (_svg?.Svg is { } skSvg)
+            {
+                skSvg.Wireframe = _wireframe;
+            }
         }
         catch (Exception e)
         {

--- a/src/Svg.Skia/SKSvg.Model.cs
+++ b/src/Svg.Skia/SKSvg.Model.cs
@@ -102,6 +102,8 @@ public partial class SKSvg : IDisposable
 
     public virtual SkiaSharp.SKPicture? Picture { get; protected set; }
 
+    public bool Wireframe { get; set; }
+
     public event EventHandler<SKSvgDrawEventArgs>? OnDraw;
 
     protected virtual void RaiseOnDraw(SKSvgDrawEventArgs e)
@@ -270,7 +272,14 @@ public partial class SKSvg : IDisposable
         }
 
         canvas.Save();
-        canvas.DrawPicture(picture);
+        if (Wireframe && Model is { })
+        {
+            SkiaModel.DrawWireframe(Model, canvas);
+        }
+        else
+        {
+            canvas.DrawPicture(picture);
+        }
         canvas.Restore();
 
         RaiseOnDraw(new SKSvgDrawEventArgs(canvas));

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -1373,4 +1373,42 @@ public class SkiaModel
             Draw(canvasCommand, skCanvas);
         }
     }
+
+    public void DrawWireframe(SKPicture picture, SkiaSharp.SKCanvas skCanvas)
+    {
+        if (picture.Commands is null)
+        {
+            return;
+        }
+
+        using var paint = new SkiaSharp.SKPaint
+        {
+            IsAntialias = true,
+            Style = SkiaSharp.SKPaintStyle.Stroke,
+            Color = SkiaSharp.SKColors.Red,
+            StrokeWidth = 1
+        };
+
+        foreach (var canvasCommand in picture.Commands)
+        {
+            switch (canvasCommand)
+            {
+                case DrawPathCanvasCommand drawPathCanvasCommand when drawPathCanvasCommand.Path is { }:
+                {
+                    var path = ToSKPath(drawPathCanvasCommand.Path);
+                    skCanvas.DrawPath(path, paint);
+                    break;
+                }
+                case DrawImageCanvasCommand drawImageCanvasCommand:
+                {
+                    var dest = ToSKRect(drawImageCanvasCommand.Dest);
+                    skCanvas.DrawRect(dest, paint);
+                    break;
+                }
+                default:
+                    Draw(canvasCommand, skCanvas);
+                    break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `Wireframe` property to `SKSvg` and render with `SkiaModel.DrawWireframe`
- add wireframe drawing logic
- expose new `Wireframe` toggle on Avalonia `Svg` control and connect to `SKSvg`
- allow toggling wireframe in TestApp UI

## Testing
- `dotnet build Svg.Skia.sln -c Release` *(fails: Could not find a part of the path '/workspace/Svg.Skia/externals/SVG/Source/Resources/svg11.dtd')*

------
https://chatgpt.com/codex/tasks/task_e_68760dfdd7508321886485725d3fa55c