### PR TITLE
Fix feConvolveMatrix default target handling

### DIFF
--- a/src/Svg.Model/SvgFilterContext.cs
+++ b/src/Svg.Model/SvgFilterContext.cs
@@ -1323,7 +1323,17 @@ internal class SvgFilterContext
 
         var gain = 1f / divisor;
         var bias = svgConvolveMatrix.Bias * 255f;
-        var kernelOffset = new SKPointI(svgConvolveMatrix.TargetX, svgConvolveMatrix.TargetY);
+        var targetX = svgConvolveMatrix.TargetX;
+        var targetY = svgConvolveMatrix.TargetY;
+        if (!svgConvolveMatrix.ContainsAttribute("targetX"))
+        {
+            targetX = (int)Math.Floor(orderX / 2f);
+        }
+        if (!svgConvolveMatrix.ContainsAttribute("targetY"))
+        {
+            targetY = (int)Math.Floor(orderY / 2f);
+        }
+        var kernelOffset = new SKPointI(targetX, targetY);
         var tileMode = svgConvolveMatrix.EdgeMode switch
         {
             SvgEdgeMode.Duplicate => SKShaderTileMode.Clamp,


### PR DESCRIPTION
## Summary
- fix targetX/targetY defaults for feConvolveMatrix when attributes are missing

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68760e5e37c88321a980f6a0bbb6b8eb