### PR TITLE
Fix feDiffuseLighting by using transparent black

### DIFF
--- a/src/Svg.Model/Services/FilterEffectsService.cs
+++ b/src/Svg.Model/Services/FilterEffectsService.cs
@@ -7,7 +7,7 @@ namespace Svg.Model.Services;
 
 internal static class FilterEffectsService
 {
-    internal static SKColor s_transparentBlack = new(0, 0, 0, 255);
+    internal static SKColor s_transparentBlack = new(0, 0, 0, 0);
 
     internal static bool IsNone(this Uri uri)
     {


### PR DESCRIPTION
## Summary
- ensure transparent black constant actually has 0 alpha to correctly handle feDiffuseLighting

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68760e8a4f6c8321b1dc1a0b119d3380