### PR TITLE
Fix displacement map color interpolation

### DIFF
--- a/src/Svg.Model/SvgFilterContext.cs
+++ b/src/Svg.Model/SvgFilterContext.cs
@@ -430,7 +430,7 @@ internal class SvgFilterContext
 
                 var skFilterPrimitiveRegion = GetFilterPrimitiveRegion(primitiveContext, input1FilterResult, input2FilterResult, input1Key, input2Key);
                 var skCropRect = skFilterPrimitiveRegion;
-                var displacement = ApplyColourInterpolation(input2FilterResult, input2FilterResult.ColorSpace)!;
+                var displacement = ApplyColourInterpolation(input2FilterResult, colorInterpolationFilters)!;
                 var input = ApplyColourInterpolation(input1FilterResult, colorInterpolationFilters);
                 var skImageFilter = CreateDisplacementMap(svgDisplacementMap, displacement, input, skCropRect);
                 _lastResult = GetFilterResult(svgFilterPrimitive, skImageFilter, colorInterpolationFilters);


### PR DESCRIPTION
## Summary
- apply filter color interpolation to displacement map input

## Testing
- `bash build.sh --target Test` *(fails: error CS1566 reading resource svg11.dtd)*

------
https://chatgpt.com/codex/tasks/task_e_68760e992c4c832182a23fb296cc0484