### PR TITLE
Fix fePointLight lighting position

### DIFF
--- a/src/Svg.Model/Services/TransformsService.cs
+++ b/src/Svg.Model/Services/TransformsService.cs
@@ -130,7 +130,7 @@ internal static class TransformsService
 
     internal static float CalculateOtherPercentageValue(this SKRect skBounds)
     {
-        return (float)(Math.Sqrt(skBounds.Width * skBounds.Width + skBounds.Width * skBounds.Height) / Math.Sqrt(2.0));
+        return (float)(Math.Sqrt(skBounds.Width * skBounds.Width + skBounds.Height * skBounds.Height) / Math.Sqrt(2.0));
     }
 
     internal static SvgUnit Normalize(this SvgUnit svgUnit, SvgCoordinateUnits svgCoordinateUnits)


### PR DESCRIPTION
## Summary
- correct Z scale calculation for lighting filters
- fePointLight works with accurate positioning

## Testing
- `dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68760ed5c9bc8321a66bdc44b850f2aa