### PR TITLE
Fix specular lighting clamping

### DIFF
--- a/src/Svg.Model/SvgFilterContext.cs
+++ b/src/Svg.Model/SvgFilterContext.cs
@@ -1393,6 +1393,14 @@ internal class SvgFilterContext
                     var location = GetPoint3(svgSpotLight.X, svgSpotLight.Y, svgSpotLight.Z);
                     var target = GetPoint3(svgSpotLight.PointsAtX, svgSpotLight.PointsAtY, svgSpotLight.PointsAtZ);
                     var specularExponentSpotLight = svgSpotLight.SpecularExponent;
+                    if (specularExponentSpotLight < 1f)
+                    {
+                        specularExponentSpotLight = 1f;
+                    }
+                    else if (specularExponentSpotLight > 128f)
+                    {
+                        specularExponentSpotLight = 128f;
+                    }
                     var limitingConeAngle = svgSpotLight.LimitingConeAngle;
                     if (float.IsNaN(limitingConeAngle) || limitingConeAngle > 90f || limitingConeAngle < -90f)
                     {
@@ -1607,7 +1615,19 @@ internal class SvgFilterContext
 
         var surfaceScale = svgSpecularLighting.SurfaceScale;
         var specularConstant = svgSpecularLighting.SpecularConstant;
+        if (specularConstant < 0f)
+        {
+            specularConstant = 0f;
+        }
         var specularExponent = svgSpecularLighting.SpecularExponent;
+        if (specularExponent < 1f)
+        {
+            specularExponent = 1f;
+        }
+        else if (specularExponent > 128f)
+        {
+            specularExponent = 128f;
+        }
         // TODO: svgSpecularLighting.KernelUnitLength
 
         switch (svgSpecularLighting.LightSource)
@@ -1627,6 +1647,14 @@ internal class SvgFilterContext
                     var location = GetPoint3(svgSpotLight.X, svgSpotLight.Y, svgSpotLight.Z);
                     var target = GetPoint3(svgSpotLight.PointsAtX, svgSpotLight.PointsAtY, svgSpotLight.PointsAtZ);
                     var specularExponentSpotLight = svgSpotLight.SpecularExponent;
+                    if (specularExponentSpotLight < 1f)
+                    {
+                        specularExponentSpotLight = 1f;
+                    }
+                    else if (specularExponentSpotLight > 128f)
+                    {
+                        specularExponentSpotLight = 128f;
+                    }
                     var limitingConeAngle = svgSpotLight.LimitingConeAngle;
                     if (float.IsNaN(limitingConeAngle) || limitingConeAngle > 90f || limitingConeAngle < -90f)
                     {


### PR DESCRIPTION
## Summary
- clamp negative/overlarge values for feSpecularLighting parameters
- clamp specularExponent for spotlight lights as well

## Testing
- `./build.sh --target test` *(fails: A compatible .NET SDK was not found and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68760f0b01888321aa0b1b68a7cbb391