### PR TITLE
Add glass effect menu

### DIFF
--- a/samples/AvalonDraw/GlassEffectWindow.axaml
+++ b/samples/AvalonDraw/GlassEffectWindow.axaml
@@ -1,0 +1,36 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="AvalonDraw.GlassEffectWindow"
+        Width="300" Height="280"
+        Title="Glass Effect">
+    <StackPanel Margin="10" Spacing="4">
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Angle:" VerticalAlignment="Center"/>
+            <TextBox x:Name="AngleBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Intensity:" VerticalAlignment="Center"/>
+            <TextBox x:Name="IntensityBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Refraction:" VerticalAlignment="Center"/>
+            <TextBox x:Name="RefractionBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Depth:" VerticalAlignment="Center"/>
+            <TextBox x:Name="DepthBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Dispersion:" VerticalAlignment="Center"/>
+            <TextBox x:Name="DispersionBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Frost:" VerticalAlignment="Center"/>
+            <TextBox x:Name="FrostBox" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4" Margin="0,10,0,0">
+            <Button Content="OK" Click="OkButton_OnClick" Width="80"/>
+            <Button Content="Cancel" Click="CancelButton_OnClick" Width="80"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/samples/AvalonDraw/GlassEffectWindow.axaml.cs
+++ b/samples/AvalonDraw/GlassEffectWindow.axaml.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AvalonDraw;
+
+public partial class GlassEffectWindow : Window
+{
+    private readonly TextBox _angleBox;
+    private readonly TextBox _intensityBox;
+    private readonly TextBox _refractionBox;
+    private readonly TextBox _depthBox;
+    private readonly TextBox _dispersionBox;
+    private readonly TextBox _frostBox;
+
+    public GlassEffectWindow()
+    {
+        InitializeComponent();
+        _angleBox = this.FindControl<TextBox>("AngleBox");
+        _intensityBox = this.FindControl<TextBox>("IntensityBox");
+        _refractionBox = this.FindControl<TextBox>("RefractionBox");
+        _depthBox = this.FindControl<TextBox>("DepthBox");
+        _dispersionBox = this.FindControl<TextBox>("DispersionBox");
+        _frostBox = this.FindControl<TextBox>("FrostBox");
+
+        _angleBox.Text = "45";
+        _intensityBox.Text = "1";
+        _refractionBox.Text = "0";
+        _depthBox.Text = "1";
+        _dispersionBox.Text = "0";
+        _frostBox.Text = "5";
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public float Angle { get; private set; }
+    public float Intensity { get; private set; }
+    public float Refraction { get; private set; }
+    public float Depth { get; private set; }
+    public float Dispersion { get; private set; }
+    public float Frost { get; private set; }
+
+    private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        float.TryParse(_angleBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var a);
+        float.TryParse(_intensityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var i);
+        float.TryParse(_refractionBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var r);
+        float.TryParse(_depthBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var d);
+        float.TryParse(_dispersionBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var di);
+        float.TryParse(_frostBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var f);
+
+        Angle = a;
+        Intensity = i;
+        Refraction = r;
+        Depth = d;
+        Dispersion = di;
+        Frost = f;
+        Close(true);
+    }
+
+    private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -76,13 +76,16 @@
                 <MenuItem Header="Path Cubic" Click="PathCubicToolMenuItem_Click" InputGesture="J"/>
                 <MenuItem Header="Path Quadratic" Click="PathQuadraticToolMenuItem_Click" InputGesture="Q"/>
                 <MenuItem Header="Path Arc" Click="PathArcToolMenuItem_Click" InputGesture="A"/>
-                <MenuItem Header="Path Move" Click="PathMoveToolMenuItem_Click" InputGesture="M"/>
-            </MenuItem>
-            <MenuItem Header="View">
-                <MenuItem Header="Wireframe" Click="WireframeMenuItem_Click"/>
-                <MenuItem Header="Disable Filters" Click="FiltersMenuItem_Click"/>
-                <MenuItem Header="Settings..." Click="SettingsMenuItem_Click"/>
-            </MenuItem>
+            <MenuItem Header="Path Move" Click="PathMoveToolMenuItem_Click" InputGesture="M"/>
+        </MenuItem>
+        <MenuItem Header="Effects">
+            <MenuItem Header="Glass..." Click="GlassEffectMenuItem_Click"/>
+        </MenuItem>
+        <MenuItem Header="View">
+            <MenuItem Header="Wireframe" Click="WireframeMenuItem_Click"/>
+            <MenuItem Header="Disable Filters" Click="FiltersMenuItem_Click"/>
+            <MenuItem Header="Settings..." Click="SettingsMenuItem_Click"/>
+        </MenuItem>
         </Menu>
         <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="4">
             <RadioButton Content="Select" GroupName="tools" IsChecked="True" Click="SelectToolButton_Click" />


### PR DESCRIPTION
## Summary
- implement a new **Effects** menu with a Glass effect entry
- add `GlassEffectWindow` with angle/intensity/refraction/depth/dispersion/frost inputs
- hook up `GlassEffectMenuItem_Click` in `MainWindow` to apply a filter composed of blur, lighting and blend primitives

## Testing
- `dotnet test Svg.Skia.sln --verbosity normal -p:RepositoryUrl=https://example.com`

------
https://chatgpt.com/codex/tasks/task_e_68796a0951cc832190c7b2b16371f995