### PR TITLE
Add hidden filter & shift/ctrl multi-select

### DIFF
--- a/samples/AvalonDraw/SettingsWindow.axaml
+++ b/samples/AvalonDraw/SettingsWindow.axaml
@@ -1,11 +1,12 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="AvalonDraw.SettingsWindow"
-        Width="250" Height="150"
+        Width="250" Height="170"
         Title="Settings">
     <StackPanel Margin="10" Spacing="4">
         <CheckBox x:Name="SnapCheckBox" Content="Enable Snap To Grid"/>
         <CheckBox x:Name="GridCheckBox" Content="Show Grid" Margin="0,4,0,0"/>
+        <CheckBox x:Name="HiddenSelectCheckBox" Content="Include Hidden Elements" Margin="0,4,0,0"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="Grid Size:" VerticalAlignment="Center"/>
             <TextBox x:Name="GridSizeBox" Width="80"/>

--- a/samples/AvalonDraw/SettingsWindow.axaml.cs
+++ b/samples/AvalonDraw/SettingsWindow.axaml.cs
@@ -9,16 +9,19 @@ public partial class SettingsWindow : Window
 {
     private readonly CheckBox _snapCheckBox;
     private readonly CheckBox _gridCheckBox;
+    private readonly CheckBox _hiddenSelectCheckBox;
     private readonly TextBox _gridSizeBox;
 
-    public SettingsWindow(bool snapToGrid, double gridSize, bool showGrid)
+    public SettingsWindow(bool snapToGrid, double gridSize, bool showGrid, bool includeHidden)
     {
         InitializeComponent();
         _snapCheckBox = this.FindControl<CheckBox>("SnapCheckBox");
         _gridCheckBox = this.FindControl<CheckBox>("GridCheckBox");
+        _hiddenSelectCheckBox = this.FindControl<CheckBox>("HiddenSelectCheckBox");
         _gridSizeBox = this.FindControl<TextBox>("GridSizeBox");
         _snapCheckBox.IsChecked = snapToGrid;
         _gridCheckBox.IsChecked = showGrid;
+        _hiddenSelectCheckBox.IsChecked = includeHidden;
         _gridSizeBox.Text = gridSize.ToString(CultureInfo.InvariantCulture);
     }
 
@@ -30,11 +33,13 @@ public partial class SettingsWindow : Window
     public bool SnapToGrid { get; private set; }
     public bool ShowGrid { get; private set; }
     public double GridSize { get; private set; }
+    public bool IncludeHidden { get; private set; }
 
     private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         SnapToGrid = _snapCheckBox.IsChecked ?? false;
         ShowGrid = _gridCheckBox.IsChecked ?? false;
+        IncludeHidden = _hiddenSelectCheckBox.IsChecked ?? false;
         if (double.TryParse(_gridSizeBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var size))
             GridSize = size;
         else


### PR DESCRIPTION
## Summary
- allow including hidden elements via settings
- support Shift/Ctrl modify mode for multi-select
- skip hidden elements when selecting if option disabled

## Testing
- `dotnet build Svg.Skia.sln -c Release`
- `dotnet test Svg.Skia.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a3a88d3988321b52063050a17fa7b