### PR TITLE
Add basic pattern fill editor

### DIFF
--- a/samples/AvalonDraw/PatternEditorWindow.axaml
+++ b/samples/AvalonDraw/PatternEditorWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="AvalonDraw.PatternEditorWindow"
+        Width="400" Height="300"
+        Title="Edit Pattern">
+    <StackPanel Margin="10" Spacing="4">
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="Width:" VerticalAlignment="Center"/>
+            <TextBox x:Name="WidthBox" Width="60"/>
+            <TextBlock Text="Height:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+            <TextBox x:Name="HeightBox" Width="60"/>
+        </StackPanel>
+        <TextBlock Text="Path Data:"/>
+        <TextBox x:Name="PathBox" AcceptsReturn="True" Height="120"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
+            <Button Content="OK" Width="80" Click="OkButton_OnClick"/>
+            <Button Content="Cancel" Width="80" Click="CancelButton_OnClick"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/samples/AvalonDraw/PatternEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/PatternEditorWindow.axaml.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Svg;
+using Svg.Pathing;
+
+namespace AvalonDraw;
+
+public partial class PatternEditorWindow : Window
+{
+    private readonly TextBox _widthBox;
+    private readonly TextBox _heightBox;
+    private readonly TextBox _pathBox;
+
+    public PatternEditorWindow()
+    {
+        InitializeComponent();
+        _widthBox = this.FindControl<TextBox>("WidthBox");
+        _heightBox = this.FindControl<TextBox>("HeightBox");
+        _pathBox = this.FindControl<TextBox>("PathBox");
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public SvgPatternServer? Result { get; private set; }
+
+    private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        float.TryParse(_widthBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var w);
+        float.TryParse(_heightBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var h);
+        if (w <= 0)
+            w = 10f;
+        if (h <= 0)
+            h = 10f;
+        var pat = new SvgPatternServer
+        {
+            Width = new SvgUnit(w),
+            Height = new SvgUnit(h)
+        };
+        if (!string.IsNullOrWhiteSpace(_pathBox.Text))
+        {
+            var path = new SvgPath
+            {
+                PathData = SvgPathBuilder.Parse(_pathBox.Text),
+                Fill = new SvgColourServer(System.Drawing.Color.Black)
+            };
+            pat.Children.Add(path);
+        }
+        Result = pat;
+        Close(true);
+    }
+
+    private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/samples/AvalonDraw/Services/PatternService.cs
+++ b/samples/AvalonDraw/Services/PatternService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Svg;
+
+namespace AvalonDraw.Services;
+
+public class PatternService
+{
+    public class PatternEntry
+    {
+        public SvgPatternServer Pattern { get; }
+        public string Name { get; }
+
+        public PatternEntry(SvgPatternServer pattern, string name)
+        {
+            Pattern = pattern;
+            Name = name;
+        }
+
+        public override string ToString() => Name;
+    }
+
+    public ObservableCollection<PatternEntry> Patterns { get; } = new();
+
+    public void Load(SvgDocument? document)
+    {
+        Patterns.Clear();
+        if (document is null)
+            return;
+        int index = 1;
+        foreach (var p in document.Descendants().OfType<SvgPatternServer>())
+        {
+            var name = string.IsNullOrEmpty(p.ID) ? $"Pattern {index++}" : p.ID!;
+            Patterns.Add(new PatternEntry(p, name));
+        }
+    }
+
+    public void AddPattern(SvgDocument document, SvgPatternServer pattern)
+    {
+        document.Children.Add(pattern);
+        var name = string.IsNullOrEmpty(pattern.ID) ? $"Pattern {Patterns.Count + 1}" : pattern.ID!;
+        Patterns.Add(new PatternEntry(pattern, name));
+    }
+}


### PR DESCRIPTION
## Summary
- add `PatternService` to manage pattern definitions
- create a `PatternEditorWindow` for editing pattern cells
- integrate patterns into the property editor

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_687a433349a08321b5688ced876558ea