### PR TITLE
Add appearance layer support

### DIFF
--- a/samples/AvalonDraw/Services/AppearanceLayer.cs
+++ b/samples/AvalonDraw/Services/AppearanceLayer.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+
+namespace AvalonDraw.Services;
+
+public enum AppearanceEffect
+{
+    None,
+    DropShadow,
+    Blur
+}
+
+public class AppearanceLayer : INotifyPropertyChanged
+{
+    private string? _fill;
+    private string? _stroke;
+    private float _strokeWidth;
+    private AppearanceEffect _effect;
+    private float _blurRadius;
+    private float _shadowOffsetX;
+    private float _shadowOffsetY;
+    private string? _shadowColor;
+
+    public string? Fill
+    {
+        get => _fill;
+        set
+        {
+            if (_fill != value)
+            {
+                _fill = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Fill)));
+            }
+        }
+    }
+
+    public string? Stroke
+    {
+        get => _stroke;
+        set
+        {
+            if (_stroke != value)
+            {
+                _stroke = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Stroke)));
+            }
+        }
+    }
+
+    public float StrokeWidth
+    {
+        get => _strokeWidth;
+        set
+        {
+            if (_strokeWidth != value)
+            {
+                _strokeWidth = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(StrokeWidth)));
+            }
+        }
+    }
+
+    public AppearanceEffect Effect
+    {
+        get => _effect;
+        set
+        {
+            if (_effect != value)
+            {
+                _effect = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Effect)));
+            }
+        }
+    }
+
+    public float BlurRadius
+    {
+        get => _blurRadius;
+        set
+        {
+            if (_blurRadius != value)
+            {
+                _blurRadius = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BlurRadius)));
+            }
+        }
+    }
+
+    public float ShadowOffsetX
+    {
+        get => _shadowOffsetX;
+        set
+        {
+            if (_shadowOffsetX != value)
+            {
+                _shadowOffsetX = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShadowOffsetX)));
+            }
+        }
+    }
+
+    public float ShadowOffsetY
+    {
+        get => _shadowOffsetY;
+        set
+        {
+            if (_shadowOffsetY != value)
+            {
+                _shadowOffsetY = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShadowOffsetY)));
+            }
+        }
+    }
+
+    public string? ShadowColor
+    {
+        get => _shadowColor;
+        set
+        {
+            if (_shadowColor != value)
+            {
+                _shadowColor = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShadowColor)));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}
+


### PR DESCRIPTION
## Summary
- add `AppearanceLayer` model for multiple fills/strokes
- extend `PropertiesService` to load and apply appearance layers

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a9b5f11288321a8d35fe994877adb