### PR TITLE
Implement Blend shape interpolation

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -64,6 +64,7 @@
                 <MenuItem Header="Unite" Click="UniteMenuItem_Click" InputGesture="Ctrl+Shift+U"/>
                 <MenuItem Header="Subtract" Click="SubtractMenuItem_Click" InputGesture="Ctrl+Shift+D"/>
                 <MenuItem Header="Intersect" Click="IntersectMenuItem_Click" InputGesture="Ctrl+Shift+I"/>
+                <MenuItem Header="Blend" Click="BlendMenuItem_Click" InputGesture="Ctrl+Shift+B"/>
                 <Separator />
                 <MenuItem Header="New Layer" Click="NewLayerMenuItem_Click"/>
                 <MenuItem Header="Delete Layer" Click="DeleteLayerMenuItem_Click"/>

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2836,6 +2836,29 @@ public partial class MainWindow : Window
         SelectNodeFromElement(result);
     }
 
+    private void BlendSelected()
+    {
+        if (_document is null || _multiSelected.Count != 2)
+            return;
+
+        if (_multiSelected[0] is not SvgPath from || _multiSelected[1] is not SvgPath to)
+            return;
+        if (from.Parent is not SvgElement parent)
+            return;
+
+        SaveUndoState();
+
+        var blends = _pathService.Blend(from, to, 5);
+        var index = parent.Children.IndexOf(to);
+        foreach (var p in blends)
+        {
+            parent.Children.Insert(index++, p);
+        }
+
+        SvgView.SkSvg!.FromSvgDocument(_document);
+        BuildTree();
+    }
+
     private void SmoothPointMenuItem_Click(object? sender, RoutedEventArgs e)
     {
         if (_pathService.IsEditing && _pathService.ActivePoint >= 0 && _document is { })
@@ -2863,6 +2886,7 @@ public partial class MainWindow : Window
     private void UniteMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Union);
     private void SubtractMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Difference);
     private void IntersectMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Intersect);
+    private void BlendMenuItem_Click(object? sender, RoutedEventArgs e) => BlendSelected();
 
     private void AlignLeftMenuItem_Click(object? sender, RoutedEventArgs e) => AlignSelected(AlignService.AlignType.Left);
     private void AlignHCenterMenuItem_Click(object? sender, RoutedEventArgs e) => AlignSelected(AlignService.AlignType.HCenter);


### PR DESCRIPTION
## Summary
- add BlendSelected UI handler for inserting interpolated paths
- create Blend menu item in AvalonDraw sample
- implement basic path interpolation in PathService

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false -p:EnableSourceControlManagerQueries=false`
- `dotnet test Svg.Skia.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a9b5903fc8321b967aaa23d8641d0