### PR TITLE
Add clipping mask command

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -64,6 +64,7 @@
                 <MenuItem Header="Unite" Click="UniteMenuItem_Click" InputGesture="Ctrl+Shift+U"/>
                 <MenuItem Header="Subtract" Click="SubtractMenuItem_Click" InputGesture="Ctrl+Shift+D"/>
                 <MenuItem Header="Intersect" Click="IntersectMenuItem_Click" InputGesture="Ctrl+Shift+I"/>
+                <MenuItem Header="Create Clipping Mask" Click="CreateClippingMaskMenuItem_Click"/>
                 <Separator />
                 <MenuItem Header="New Layer" Click="NewLayerMenuItem_Click"/>
                 <MenuItem Header="Delete Layer" Click="DeleteLayerMenuItem_Click"/>

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2863,6 +2863,7 @@ public partial class MainWindow : Window
     private void UniteMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Union);
     private void SubtractMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Difference);
     private void IntersectMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Intersect);
+    private void CreateClippingMaskMenuItem_Click(object? sender, RoutedEventArgs e) => CreateClippingMask();
 
     private void AlignLeftMenuItem_Click(object? sender, RoutedEventArgs e) => AlignSelected(AlignService.AlignType.Left);
     private void AlignHCenterMenuItem_Click(object? sender, RoutedEventArgs e) => AlignSelected(AlignService.AlignType.HCenter);
@@ -2927,6 +2928,43 @@ public partial class MainWindow : Window
         SvgView.SkSvg!.FromSvgDocument(_document);
         UpdateSelectedDrawable();
         SvgView.InvalidateVisual();
+    }
+
+    private SvgClipPath CreateClipPath(SvgVisualElement mask, string id)
+    {
+        if (mask.Parent is SvgElement parent)
+            parent.Children.Remove(mask);
+        var clip = new SvgClipPath { ID = id };
+        clip.Children.Add(mask);
+        return clip;
+    }
+
+    private void CreateClippingMask()
+    {
+        if (_document is null || _multiSelected.Count != 2)
+            return;
+
+        if (_multiSelected[0] is not SvgVisualElement first || _multiSelected[1] is not SvgVisualElement second)
+            return;
+
+        var clipId = string.IsNullOrEmpty(second.ID)
+            ? $"clip{_document.Descendants().OfType<SvgClipPath>().Count() + 1}"
+            : second.ID;
+        second.ID = clipId;
+
+        SaveUndoState();
+
+        var clip = CreateClipPath(second, clipId);
+        first.Children.Add(clip);
+        first.ClipPath = new Uri($"#{clipId}", UriKind.Relative);
+
+        _multiSelected.Clear();
+        _multiDrawables.Clear();
+        _multiBounds = SK.SKRect.Empty;
+
+        SvgView.SkSvg!.FromSvgDocument(_document);
+        BuildTree();
+        SelectNodeFromElement(first);
     }
 
     private void LayerAdd()


### PR DESCRIPTION
## Summary
- add "Create Clipping Mask" menu item
- implement helper methods to create SvgClipPath and apply mask

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com -p:ContinuousIntegrationBuild=false`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com -p:ContinuousIntegrationBuild=false`

------
https://chatgpt.com/codex/tasks/task_e_687a9b3d7ea0832185622ae0f801cfef