### PR TITLE
Add flip operations

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -109,6 +109,9 @@
                 <Separator/>
                 <MenuItem Header="Distribute Horizontal" Click="DistributeHMenuItem_Click"/>
                 <MenuItem Header="Distribute Vertical" Click="DistributeVMenuItem_Click"/>
+                <Separator/>
+                <MenuItem Header="Flip Horizontal" Click="FlipHMenuItem_Click"/>
+                <MenuItem Header="Flip Vertical" Click="FlipVMenuItem_Click"/>
             </MenuItem>
             <MenuItem Header="View">
                 <MenuItem Header="Wireframe" Click="WireframeMenuItem_Click"/>

--- a/samples/AvalonDraw/Services/SelectionService.cs
+++ b/samples/AvalonDraw/Services/SelectionService.cs
@@ -198,6 +198,22 @@ public class SelectionService
         }
     }
 
+    public void FlipHorizontal(SvgVisualElement element, SK.SKPoint center)
+    {
+        element.Transforms ??= new SvgTransformCollection();
+        element.Transforms.Add(new SvgTranslate(center.X, center.Y));
+        element.Transforms.Add(new SvgScale(-1, 1));
+        element.Transforms.Add(new SvgTranslate(-center.X, -center.Y));
+    }
+
+    public void FlipVertical(SvgVisualElement element, SK.SKPoint center)
+    {
+        element.Transforms ??= new SvgTransformCollection();
+        element.Transforms.Add(new SvgTranslate(center.X, center.Y));
+        element.Transforms.Add(new SvgScale(1, -1));
+        element.Transforms.Add(new SvgTranslate(-center.X, -center.Y));
+    }
+
     public float Snap(float value)
     {
         if (!SnapToGrid || GridSize <= 0)


### PR DESCRIPTION
## Summary
- add horizontal/vertical flip methods in `SelectionService`
- expose flip commands in AvalonDraw menu
- integrate flip actions with undo stack

## Testing
- `dotnet format samples/AvalonDraw/AvalonDraw.csproj --no-restore --verbosity minimal`
- `dotnet build Svg.Skia.sln -c Release` *(fails: Repository URL not valid)*
- `dotnet test Svg.Skia.sln -c Release` *(fails: Repository URL not valid)*

------
https://chatgpt.com/codex/tasks/task_e_687aa57a52988321b884ddb3784f1336