### PR TITLE
Add freehand brush tool

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -90,6 +90,7 @@
                 <MenuItem Header="Text Path" Click="TextPathToolMenuItem_Click" InputGesture="K"/>
                 <MenuItem Header="Text Area" Click="TextAreaToolMenuItem_Click" InputGesture="H"/>
                 <MenuItem Header="Symbol" Click="SymbolToolMenuItem_Click" InputGesture="U"/>
+                <MenuItem Header="Freehand" Click="FreehandToolMenuItem_Click" InputGesture="F"/>
                 <Separator/>
                 <MenuItem Header="Path Line" Click="PathLineToolMenuItem_Click" InputGesture="B"/>
                 <MenuItem Header="Path Cubic" Click="PathCubicToolMenuItem_Click" InputGesture="J"/>
@@ -132,11 +133,14 @@
             <RadioButton Content="TextPath" GroupName="tools" Margin="4,0" Click="TextPathToolButton_Click" />
             <RadioButton Content="TextArea" GroupName="tools" Margin="4,0" Click="TextAreaToolButton_Click" />
             <RadioButton Content="Symbol" GroupName="tools" Margin="4,0" Click="SymbolToolButton_Click" />
+            <RadioButton Content="Free" GroupName="tools" Margin="4,0" Click="FreehandToolButton_Click" />
             <RadioButton Content="PLine" GroupName="tools" Margin="4,0" Click="PathLineToolButton_Click" />
             <RadioButton Content="PCubic" GroupName="tools" Margin="4,0" Click="PathCubicToolButton_Click" />
             <RadioButton Content="PQuad" GroupName="tools" Margin="4,0" Click="PathQuadraticToolButton_Click" />
             <RadioButton Content="PArc" GroupName="tools" Margin="4,0" Click="PathArcToolButton_Click" />
             <RadioButton Content="PMove" GroupName="tools" Margin="4,0" Click="PathMoveToolButton_Click" />
+            <TextBlock Text="Width:" VerticalAlignment="Center" Margin="8,0,0,0"/>
+            <TextBox x:Name="StrokeWidthBox" Width="50" KeyUp="StrokeWidthBox_OnKeyUp" />
         </StackPanel>
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>

--- a/samples/AvalonDraw/Services/PathService.cs
+++ b/samples/AvalonDraw/Services/PathService.cs
@@ -358,6 +358,30 @@ public class PathService
         return pts;
     }
 
+    public static SvgPathSegmentList MakeSmooth(IList<Shim.SKPoint> points)
+    {
+        var list = new SvgPathSegmentList();
+        if (points.Count == 0)
+            return list;
+        list.Add(new SvgMoveToSegment(false, new System.Drawing.PointF(points[0].X, points[0].Y)));
+        if (points.Count == 1)
+            return list;
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            var p0 = i == 0 ? points[i] : points[i - 1];
+            var p1 = points[i];
+            var p2 = points[i + 1];
+            var p3 = i + 2 < points.Count ? points[i + 2] : p2;
+            var c1 = new Shim.SKPoint(p1.X + (p2.X - p0.X) / 6f, p1.Y + (p2.Y - p0.Y) / 6f);
+            var c2 = new Shim.SKPoint(p2.X - (p3.X - p1.X) / 6f, p2.Y - (p3.Y - p1.Y) / 6f);
+            list.Add(new SvgCubicCurveSegment(false,
+                new System.Drawing.PointF(c1.X, c1.Y),
+                new System.Drawing.PointF(c2.X, c2.Y),
+                new System.Drawing.PointF(p2.X, p2.Y)));
+        }
+        return list;
+    }
+
     public static void AddPathSegments(SK.SKPath path, SvgPathSegmentList segments)
     {
         var cur = new SK.SKPoint();


### PR DESCRIPTION
## Summary
- extend Tool enum with Freehand and add creation helpers
- capture pointer movement to build freehand path
- smooth recorded points into cubic curves
- expose stroke width input and UI options

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release -p:EnableSourceLink=false`

------
https://chatgpt.com/codex/tasks/task_e_687aa5995f1483218afc511232d44aa8