### PR TITLE
Add advanced pathfinder operations

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml
+++ b/samples/AvalonDraw/MainWindow.axaml
@@ -64,6 +64,9 @@
                 <MenuItem Header="Unite" Click="UniteMenuItem_Click" InputGesture="Ctrl+Shift+U"/>
                 <MenuItem Header="Subtract" Click="SubtractMenuItem_Click" InputGesture="Ctrl+Shift+D"/>
                 <MenuItem Header="Intersect" Click="IntersectMenuItem_Click" InputGesture="Ctrl+Shift+I"/>
+                <MenuItem Header="Exclude" Click="ExcludeMenuItem_Click" InputGesture="Ctrl+Shift+E"/>
+                <MenuItem Header="Divide" Click="DivideMenuItem_Click" InputGesture="Ctrl+Shift+V"/>
+                <MenuItem Header="Trim" Click="TrimMenuItem_Click" InputGesture="Ctrl+Shift+T"/>
                 <MenuItem Header="Create Clipping Mask" Click="CreateClippingMaskMenuItem_Click"/>
                 <MenuItem Header="Blend" Click="BlendMenuItem_Click" InputGesture="Ctrl+Shift+B"/>
                 <Separator />

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -3061,6 +3061,9 @@ public partial class MainWindow : Window
     private void UniteMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Union);
     private void SubtractMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Difference);
     private void IntersectMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Intersect);
+    private void ExcludeMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Xor);
+    private void DivideMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.ReverseDifference);
+    private void TrimMenuItem_Click(object? sender, RoutedEventArgs e) => ApplyPathOp(SK.SKPathOp.Difference);
     private void CreateClippingMaskMenuItem_Click(object? sender, RoutedEventArgs e) => CreateClippingMask();
     private void BlendMenuItem_Click(object? sender, RoutedEventArgs e) => BlendSelected();
 

--- a/samples/AvalonDraw/Services/PathService.cs
+++ b/samples/AvalonDraw/Services/PathService.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using SK = SkiaSharp;
-using Svg.Transforms;
 using Svg;
 using Svg.Model.Drawables;
 using Svg.Pathing;
+using Svg.Transforms;
 using Shim = ShimSkiaSharp;
+using SK = SkiaSharp;
 
 namespace AvalonDraw.Services;
 
@@ -54,7 +54,7 @@ public class PathService
         _points.Clear();
         MakePathAbsolute(path);
         var segs = path.PathData;
-        var cur = new Shim.SKPoint(0,0);
+        var cur = new Shim.SKPoint(0, 0);
         foreach (var seg in segs)
         {
             switch (seg)
@@ -118,7 +118,7 @@ public class PathService
             SegmentTool.Quadratic => new SvgQuadraticCurveSegment(false,
                 new System.Drawing.PointF(point.X, point.Y),
                 new System.Drawing.PointF(point.X, point.Y)),
-            SegmentTool.Arc => new SvgArcSegment(10,10,0,SvgArcSize.Small,SvgArcSweep.Positive,false,
+            SegmentTool.Arc => new SvgArcSegment(10, 10, 0, SvgArcSize.Small, SvgArcSweep.Positive, false,
                 new System.Drawing.PointF(point.X, point.Y)),
             SegmentTool.Move => new SvgMoveToSegment(false, new System.Drawing.PointF(point.X, point.Y)),
             _ => new SvgLineSegment(false, new System.Drawing.PointF(point.X, point.Y))
@@ -537,6 +537,15 @@ public class PathService
 
         return path;
     }
+
+    public SvgPath? ExcludePath(SvgVisualElement? element, SvgVisualElement? clip)
+        => ApplyPathOp(element, clip, SK.SKPathOp.Xor);
+
+    public SvgPath? DividePath(SvgVisualElement? element, SvgVisualElement? clip)
+        => ApplyPathOp(element, clip, SK.SKPathOp.ReverseDifference);
+
+    public SvgPath? TrimPath(SvgVisualElement? element, SvgVisualElement? clip)
+        => ApplyPathOp(element, clip, SK.SKPathOp.Difference);
 
     private static float Lerp(float a, float b, float t) => a + (b - a) * t;
 


### PR DESCRIPTION
## Summary
- add Exclude/Divide/Trim helpers
- wire up new menu commands in AvalonDraw

## Testing
- `dotnet format --no-restore --include "samples/AvalonDraw/Services/PathService.cs" "samples/AvalonDraw/MainWindow.axaml.cs" "samples/AvalonDraw/MainWindow.axaml"`
- `dotnet build Svg.Skia.sln -c Release /p:RepositoryUrl=https://example.com/repo`
- `dotnet test Svg.Skia.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687ab1729f6483219520321bbd9a84e5