### PR TITLE
Enhance AvalonDraw typography

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2166,12 +2166,13 @@ public partial class MainWindow : Window
     {
         if (_document is null)
             return;
-        var win = new TextEditorWindow(_document.GetXML());
-        var result = await win.ShowDialog<string?>(this);
-        if (!string.IsNullOrEmpty(result))
+        var win = new TextEditorWindow(_document.GetXML(), _toolService.CurrentFontFamily,
+            _toolService.CurrentFontWeight, _toolService.CurrentLetterSpacing, _toolService.CurrentWordSpacing);
+        var ok = await win.ShowDialog<bool>(this);
+        if (ok)
         {
             SaveUndoState();
-            _document = SvgService.FromSvg(result);
+            _document = SvgService.FromSvg(win.TextResult);
             SvgView.SkSvg!.FromSvgDocument(_document);
             BuildTree();
         }
@@ -2181,12 +2182,21 @@ public partial class MainWindow : Window
     {
         if (_selectedSvgElement is SvgTextBase txt && _document is { })
         {
-            var win = new TextEditorWindow(txt.Text);
-            var result = await win.ShowDialog<string?>(this);
-            if (result is not null)
+            var win = new TextEditorWindow(
+                txt.Text,
+                txt.FontFamily,
+                txt.FontWeight,
+                txt.LetterSpacing.Value,
+                txt.WordSpacing.Value);
+            var ok2 = await win.ShowDialog<bool>(this);
+            if (ok2)
             {
                 SaveUndoState();
-                txt.Text = result;
+                txt.Text = win.TextResult;
+                txt.FontFamily = win.FontFamilyResult;
+                txt.FontWeight = win.FontWeightResult;
+                txt.LetterSpacing = new SvgUnit(SvgUnitType.User, win.LetterSpacingResult);
+                txt.WordSpacing = new SvgUnit(SvgUnitType.User, win.WordSpacingResult);
                 SvgView.SkSvg!.FromSvgDocument(_document);
                 UpdateSelectedDrawable();
                 LoadProperties(txt);

--- a/samples/AvalonDraw/Services/ToolService.cs
+++ b/samples/AvalonDraw/Services/ToolService.cs
@@ -37,6 +37,11 @@ public class ToolService
 
     public float CurrentStrokeWidth { get; set; } = 1f;
 
+    public string CurrentFontFamily { get; set; } = "Arial";
+    public SvgFontWeight CurrentFontWeight { get; set; } = SvgFontWeight.Normal;
+    public float CurrentLetterSpacing { get; set; } = 0f;
+    public float CurrentWordSpacing { get; set; } = 0f;
+
     public event Action<Tool, Tool>? ToolChanged;
 
     public void SetTool(Tool tool)
@@ -109,20 +114,32 @@ public class ToolService
             {
                 X = new SvgUnitCollection { new SvgUnit(SvgUnitType.User, start.X) },
                 Y = new SvgUnitCollection { new SvgUnit(SvgUnitType.User, start.Y) },
-                Text = "Text"
+                Text = "Text",
+                FontFamily = CurrentFontFamily,
+                FontWeight = CurrentFontWeight,
+                LetterSpacing = new SvgUnit(SvgUnitType.User, CurrentLetterSpacing),
+                WordSpacing = new SvgUnit(SvgUnitType.User, CurrentWordSpacing)
             },
             Tool.TextPath when !string.IsNullOrEmpty(ReferenceId) => new SvgTextPath
             {
                 ReferencedPath = new Uri($"#{ReferenceId}", UriKind.Relative),
                 StartOffset = new SvgUnit(SvgUnitType.User, 0),
-                Text = "Text"
+                Text = "Text",
+                FontFamily = CurrentFontFamily,
+                FontWeight = CurrentFontWeight,
+                LetterSpacing = new SvgUnit(SvgUnitType.User, CurrentLetterSpacing),
+                WordSpacing = new SvgUnit(SvgUnitType.User, CurrentWordSpacing)
             },
             Tool.TextArea when !string.IsNullOrEmpty(ReferenceId) => new SvgText
             {
                 X = new SvgUnitCollection { new SvgUnit(SvgUnitType.User, start.X) },
                 Y = new SvgUnitCollection { new SvgUnit(SvgUnitType.User, start.Y) },
                 ClipPath = new Uri($"#{ReferenceId}", UriKind.Relative),
-                Text = "Text"
+                Text = "Text",
+                FontFamily = CurrentFontFamily,
+                FontWeight = CurrentFontWeight,
+                LetterSpacing = new SvgUnit(SvgUnitType.User, CurrentLetterSpacing),
+                WordSpacing = new SvgUnit(SvgUnitType.User, CurrentWordSpacing)
             },
             Tool.PathLine => CreatePath(start, Tool.PathLine),
             Tool.PathCubic => CreatePath(start, Tool.PathCubic),

--- a/samples/AvalonDraw/TextEditorWindow.axaml
+++ b/samples/AvalonDraw/TextEditorWindow.axaml
@@ -5,6 +5,14 @@
         Title="Edit SVG Text">
     <StackPanel Margin="10" Spacing="4">
         <TextBox x:Name="Editor" AcceptsReturn="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <ComboBox x:Name="FontFamilyBox" Width="160" />
+            <ComboBox x:Name="FontWeightBox" Width="100" />
+            <TextBlock Text="Letter" VerticalAlignment="Center" />
+            <TextBox x:Name="LetterBox" Width="60" />
+            <TextBlock Text="Word" VerticalAlignment="Center" />
+            <TextBox x:Name="WordBox" Width="60" />
+        </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
             <Button Content="OK" Click="OkButton_OnClick" Width="80"/>
             <Button Content="Cancel" Click="CancelButton_OnClick" Width="80"/>

--- a/samples/AvalonDraw/TextEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/TextEditorWindow.axaml.cs
@@ -1,36 +1,92 @@
-using System.Threading.Tasks;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Svg;
 
 namespace AvalonDraw;
 
 public partial class TextEditorWindow : Window
 {
     private readonly TextBox _editor;
+    private readonly ComboBox _fontFamilyBox;
+    private readonly ComboBox _fontWeightBox;
+    private readonly TextBox _letterBox;
+    private readonly TextBox _wordBox;
 
-    public TextEditorWindow(string text)
+    public TextEditorWindow(string text, string fontFamily, SvgFontWeight weight, float letter, float word)
     {
         InitializeComponent();
         _editor = this.FindControl<TextBox>("Editor");
+        _fontFamilyBox = this.FindControl<ComboBox>("FontFamilyBox");
+        _fontWeightBox = this.FindControl<ComboBox>("FontWeightBox");
+        _letterBox = this.FindControl<TextBox>("LetterBox");
+        _wordBox = this.FindControl<TextBox>("WordBox");
+
         _editor.Text = text;
+        _fontFamilyBox.Items = FontManager.Current?.InstalledFontFamilyNames;
+        _fontFamilyBox.SelectedItem = fontFamily;
+        _fontWeightBox.Items = Enum.GetValues(typeof(FontWeight)).Cast<FontWeight>();
+        _fontWeightBox.SelectedItem = ToFontWeight(weight);
+        _letterBox.Text = letter.ToString();
+        _wordBox.Text = word.ToString();
     }
+
+    private static FontWeight ToFontWeight(SvgFontWeight w) => w switch
+    {
+        SvgFontWeight.W100 => FontWeight.Thin,
+        SvgFontWeight.W200 => FontWeight.ExtraLight,
+        SvgFontWeight.W300 => FontWeight.Light,
+        SvgFontWeight.W400 => FontWeight.Normal,
+        SvgFontWeight.W500 => FontWeight.Medium,
+        SvgFontWeight.W600 => FontWeight.SemiBold,
+        SvgFontWeight.W700 => FontWeight.Bold,
+        SvgFontWeight.W800 => FontWeight.ExtraBold,
+        SvgFontWeight.W900 => FontWeight.Black,
+        SvgFontWeight.Bold => FontWeight.Bold,
+        _ => FontWeight.Normal
+    };
+
+    private static SvgFontWeight FromFontWeight(FontWeight w) => w.Weight switch
+    {
+        100 => SvgFontWeight.W100,
+        200 => SvgFontWeight.W200,
+        300 => SvgFontWeight.W300,
+        400 => SvgFontWeight.W400,
+        500 => SvgFontWeight.W500,
+        600 => SvgFontWeight.W600,
+        700 => SvgFontWeight.W700,
+        800 => SvgFontWeight.W800,
+        900 => SvgFontWeight.W900,
+        _ => SvgFontWeight.Normal
+    };
 
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
     }
 
-    public string Result { get; private set; } = string.Empty;
+    public string TextResult { get; private set; } = string.Empty;
+    public string FontFamilyResult { get; private set; } = string.Empty;
+    public SvgFontWeight FontWeightResult { get; private set; }
+    public float LetterSpacingResult { get; private set; }
+    public float WordSpacingResult { get; private set; }
 
     private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        Result = _editor.Text;
-        Close(Result);
+        TextResult = _editor.Text;
+        FontFamilyResult = _fontFamilyBox.SelectedItem as string ?? string.Empty;
+        FontWeightResult = FromFontWeight((FontWeight)_fontWeightBox.SelectedItem!);
+        float.TryParse(_letterBox.Text, out var ls);
+        float.TryParse(_wordBox.Text, out var ws);
+        LetterSpacingResult = ls;
+        WordSpacingResult = ws;
+        Close(true);
     }
 
     private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        Close(null);
+        Close(false);
     }
 }


### PR DESCRIPTION
## Summary
- support font attributes in `ToolService`
- expose font settings in `TextEditorWindow`
- apply edited font data in `MainWindow`

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release` *(fails: Repository has no remote)*
- `dotnet test Svg.Skia.sln -c Release` *(fails: Repository has no remote)*

------
https://chatgpt.com/codex/tasks/task_e_687ab159d2148321b953cdb5ce5e7e3a