### PR TITLE
Add symbol editing window

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2586,7 +2586,7 @@ public partial class MainWindow : Window
             .ToList();
         if (ids.Count == 0)
             return;
-        var win = new SymbolSelectWindow(ids!);
+        var win = new SymbolSelectWindow(_symbolService);
         var result = await win.ShowDialog<string?>(this);
         if (result is null)
             return;

--- a/samples/AvalonDraw/Services/SymbolService.cs
+++ b/samples/AvalonDraw/Services/SymbolService.cs
@@ -20,10 +20,15 @@ public class SymbolService
         public override string ToString() => Name;
     }
 
+    private SvgDocument? _document;
+
+    public SvgDocument? Document => _document;
+
     public ObservableCollection<SymbolEntry> Symbols { get; } = new();
 
     public void Load(SvgDocument? document)
     {
+        _document = document;
         Symbols.Clear();
         if (document is null)
             return;
@@ -40,6 +45,7 @@ public class SymbolService
 
     public void AddSymbol(SvgDocument document, SvgSymbol symbol)
     {
+        _document = document;
         var defs = document.Children.OfType<SvgDefinitionList>().FirstOrDefault();
         if (defs is null)
         {
@@ -49,5 +55,24 @@ public class SymbolService
         defs.Children.Add(symbol);
         var name = string.IsNullOrEmpty(symbol.ID) ? $"Symbol {Symbols.Count + 1}" : symbol.ID!;
         Symbols.Add(new SymbolEntry(symbol, name));
+    }
+
+    public void ReplaceSymbol(SvgSymbol oldSymbol, SvgSymbol newSymbol)
+    {
+        if (_document is null)
+            return;
+        var defs = _document.Children.OfType<SvgDefinitionList>().FirstOrDefault();
+        if (defs is null)
+            return;
+        var idx = defs.Children.IndexOf(oldSymbol);
+        if (idx >= 0)
+            defs.Children[idx] = newSymbol;
+        var entry = Symbols.FirstOrDefault(s => s.Symbol == oldSymbol);
+        if (entry is not null)
+        {
+            var name = string.IsNullOrEmpty(newSymbol.ID) ? entry.Name : newSymbol.ID!;
+            var index = Symbols.IndexOf(entry);
+            Symbols[index] = new SymbolEntry(newSymbol, name);
+        }
     }
 }

--- a/samples/AvalonDraw/SymbolEditorWindow.axaml
+++ b/samples/AvalonDraw/SymbolEditorWindow.axaml
@@ -1,13 +1,10 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="AvalonDraw.SymbolSelectWindow"
-        Width="300" Height="200"
-        Title="Select Symbol">
+        x:Class="AvalonDraw.SymbolEditorWindow"
+        Width="600" Height="400"
+        Title="Edit Symbol">
     <StackPanel Margin="10" Spacing="4">
-        <AutoCompleteBox x:Name="SymbolList"
-                         MinimumPrefixLength="0"
-                         GotFocus="SymbolList_OnGotFocus"
-                         PointerPressed="SymbolList_OnPointerPressed" />
+        <TextBox x:Name="Editor" AcceptsReturn="True" VerticalAlignment="Stretch" Height="300"/>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
             <Button Content="OK" Width="80" Click="OkButton_OnClick"/>
             <Button Content="Cancel" Width="80" Click="CancelButton_OnClick"/>

--- a/samples/AvalonDraw/SymbolEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/SymbolEditorWindow.axaml.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using AvalonDraw.Services;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Svg;
+
+namespace AvalonDraw;
+
+public partial class SymbolEditorWindow : Window
+{
+    private readonly TextBox _editor;
+    private readonly SymbolService.SymbolEntry _entry;
+    private readonly SymbolService _service;
+
+    public SymbolEditorWindow(SymbolService.SymbolEntry entry, SymbolService service)
+    {
+        InitializeComponent();
+        _entry = entry;
+        _service = service;
+        _editor = this.FindControl<TextBox>("Editor");
+        _editor.Text = SymbolToXml(entry.Symbol);
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private static string SymbolToXml(SvgSymbol symbol)
+    {
+        var sb = new StringBuilder();
+        using var writer = XmlWriter.Create(new StringWriter(sb), new XmlWriterSettings { Indent = true });
+        symbol.Write(writer);
+        writer.Flush();
+        return sb.ToString();
+    }
+
+    private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var xml = $"<svg xmlns='http://www.w3.org/2000/svg'><defs>{_editor.Text}</defs></svg>";
+        try
+        {
+            var doc = SvgDocument.FromSvg<SvgDocument>(xml);
+            var defs = doc.Children.OfType<SvgDefinitionList>().FirstOrDefault();
+            var newSymbol = defs?.Children.OfType<SvgSymbol>().FirstOrDefault();
+            if (newSymbol is null)
+                throw new SvgException("Symbol not found");
+            _service.ReplaceSymbol(_entry.Symbol, newSymbol);
+            Close(true);
+        }
+        catch
+        {
+            Close(false);
+        }
+    }
+
+    private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add SymbolEditorWindow for editing symbol XML
- open editor via double-click in SymbolSelectWindow
- update SymbolService with replace logic and expose loaded document
- hook up editor window from MainWindow

## Testing
- `dotnet format samples/AvalonDraw/AvalonDraw.csproj --no-restore`
- `dotnet build Svg.Skia.sln -c Release /p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release /p:RepositoryUrl=https://example.com`

------
https://chatgpt.com/codex/tasks/task_e_687abc8c56688321917cf52b1eb04996