### PR TITLE
Enable radial gradient editing

### DIFF
--- a/samples/AvalonDraw/GradientEditorWindow.axaml
+++ b/samples/AvalonDraw/GradientEditorWindow.axaml
@@ -4,6 +4,18 @@
         Width="400" Height="300"
         Title="Edit Gradient">
     <DockPanel Margin="10" LastChildFill="True">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Spacing="4">
+            <TextBlock Text="Type:" VerticalAlignment="Center"/>
+            <ComboBox x:Name="TypeBox" Width="80">
+                <ComboBoxItem Content="Linear"/>
+                <ComboBoxItem Content="Radial"/>
+            </ComboBox>
+            <TextBlock Text="Center:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+            <TextBox x:Name="CenterXBox" Width="40"/>
+            <TextBox x:Name="CenterYBox" Width="40" Margin="4,0,0,0"/>
+            <TextBlock Text="Radius:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+            <TextBox x:Name="RadiusBox" Width="40"/>
+        </StackPanel>
         <DataGrid x:Name="StopsGrid" DockPanel.Dock="Top" AutoGenerateColumns="False">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Offset" Binding="{Binding Offset, Mode=TwoWay}" Width="80"/>

--- a/samples/AvalonDraw/GradientEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/GradientEditorWindow.axaml.cs
@@ -1,25 +1,50 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
+using AvalonDraw.Services;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
-using AvalonDraw.Services;
+using Avalonia.Markup.Xaml;
+using Svg;
 
 namespace AvalonDraw;
 
 public partial class GradientEditorWindow : Window
 {
     private readonly DataGrid _grid;
+    private readonly ComboBox _typeBox;
+    private readonly TextBox _centerXBox;
+    private readonly TextBox _centerYBox;
+    private readonly TextBox _radiusBox;
     private readonly ObservableCollection<GradientStopInfo> _stops;
+    private readonly SvgGradientServer _gradient;
 
-    public GradientEditorWindow(ObservableCollection<GradientStopInfo> stops)
+    public GradientEditorWindow(SvgGradientServer gradient)
     {
         InitializeComponent();
         Resources["ColorStringConverter"] = new ColorStringConverter();
         _grid = this.FindControl<DataGrid>("StopsGrid");
-        _stops = new ObservableCollection<GradientStopInfo>(stops.Select(s => new GradientStopInfo { Offset = s.Offset, Color = s.Color }));
+        _typeBox = this.FindControl<ComboBox>("TypeBox");
+        _centerXBox = this.FindControl<TextBox>("CenterXBox");
+        _centerYBox = this.FindControl<TextBox>("CenterYBox");
+        _radiusBox = this.FindControl<TextBox>("RadiusBox");
+
+        _gradient = gradient;
+        _stops = new ObservableCollection<GradientStopInfo>(gradient.Stops.Select(s => new GradientStopInfo { Offset = s.Offset.Value, Color = GradientStopsEntry.ColorToString(s.GetColor(gradient)) }));
         _grid.ItemsSource = _stops;
+
+        if (gradient is SvgRadialGradientServer radial)
+        {
+            _typeBox.SelectedIndex = 1;
+            _centerXBox.Text = radial.CenterX.Value.ToString(CultureInfo.InvariantCulture);
+            _centerYBox.Text = radial.CenterY.Value.ToString(CultureInfo.InvariantCulture);
+            _radiusBox.Text = radial.Radius.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            _typeBox.SelectedIndex = 0;
+        }
     }
 
     private void InitializeComponent()
@@ -27,7 +52,7 @@ public partial class GradientEditorWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
-    public ObservableCollection<GradientStopInfo> Result { get; private set; } = new();
+    public SvgGradientServer? Result { get; private set; }
 
     private void AddButton_OnClick(object? sender, RoutedEventArgs e)
     {
@@ -42,7 +67,35 @@ public partial class GradientEditorWindow : Window
 
     private void OkButton_OnClick(object? sender, RoutedEventArgs e)
     {
-        Result = new ObservableCollection<GradientStopInfo>(_stops.Select(s => new GradientStopInfo { Offset = s.Offset, Color = s.Color }));
+        SvgGradientServer grad;
+        if (_typeBox.SelectedIndex == 1)
+        {
+            var rad = _gradient as SvgRadialGradientServer ?? new SvgRadialGradientServer();
+            float.TryParse(_centerXBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var cx);
+            float.TryParse(_centerYBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var cy);
+            float.TryParse(_radiusBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var r);
+            rad.CenterX = new SvgUnit(cx);
+            rad.CenterY = new SvgUnit(cy);
+            rad.Radius = new SvgUnit(r);
+            grad = rad;
+        }
+        else
+        {
+            grad = _gradient as SvgLinearGradientServer ?? new SvgLinearGradientServer();
+        }
+
+        grad.Children.Clear();
+        foreach (var info in _stops)
+        {
+            var stop = new SvgGradientStop
+            {
+                Offset = new SvgUnit((float)info.Offset),
+                StopColor = new SvgColourServer(GradientStopsEntry.ParseColor(info.Color)),
+                StopOpacity = 1f
+            };
+            grad.Children.Add(stop);
+        }
+        Result = grad;
         Close(true);
     }
 

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -296,15 +296,21 @@ public partial class MainWindow : Window
                 var btn = new Button { Content = entry.Value ?? "Edit", VerticalAlignment = VerticalAlignment.Center };
                 btn.Click += async (_, _) =>
                 {
-                    var dlg = new GradientEditorWindow(gEntry.Stops);
+                    var dlg = new GradientEditorWindow(gEntry.Gradient);
                     var result = await dlg.ShowDialog<bool>(this);
-                    if (result)
+                    if (result && dlg.Result is { } newGrad)
                     {
-                        gEntry.Stops.Clear();
-                        foreach (var s in dlg.Result)
-                            gEntry.Stops.Add(s);
-                        gEntry.UpdateValue();
+                        if (!ReferenceEquals(newGrad, gEntry.Gradient) && gEntry.Gradient.Parent is SvgElement parent)
+                        {
+                            var idx = parent.Children.IndexOf(gEntry.Gradient);
+                            if (idx >= 0)
+                                parent.Children[idx] = newGrad;
+                            _selectedSvgElement = newGrad;
+                        }
+                        gEntry.SetGradient(newGrad);
                         gEntry.NotifyChanged();
+                        if (_selectedSvgElement is { })
+                            _propertiesService.LoadProperties(_selectedSvgElement);
                     }
                 };
                 return btn;

--- a/samples/AvalonDraw/Services/GradientEntry.cs
+++ b/samples/AvalonDraw/Services/GradientEntry.cs
@@ -16,10 +16,12 @@ public class GradientStopInfo
 public class GradientStopsEntry : PropertyEntry
 {
     public ObservableCollection<GradientStopInfo> Stops { get; }
+    public SvgGradientServer Gradient { get; private set; }
 
     public GradientStopsEntry(SvgGradientServer gradient)
         : base("Stops", $"{gradient.Stops.Count} stops", (_, __) => { })
     {
+        Gradient = gradient;
         Stops = new ObservableCollection<GradientStopInfo>(
             gradient.Stops.Select(s => new GradientStopInfo
             {
@@ -28,10 +30,19 @@ public class GradientStopsEntry : PropertyEntry
             }));
     }
 
-    private static string ColorToString(System.Drawing.Color c)
+    public void SetGradient(SvgGradientServer gradient)
+    {
+        Gradient = gradient;
+        Stops.Clear();
+        foreach (var s in gradient.Stops)
+            Stops.Add(new GradientStopInfo { Offset = s.Offset.Value, Color = ColorToString(s.GetColor(gradient)) });
+        UpdateValue();
+    }
+
+    internal static string ColorToString(System.Drawing.Color c)
         => $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
 
-    private static System.Drawing.Color ParseColor(string color)
+    internal static System.Drawing.Color ParseColor(string color)
     {
         var ac = Color.Parse(color);
         return System.Drawing.Color.FromArgb(ac.A, ac.R, ac.G, ac.B);

--- a/samples/AvalonDraw/Services/PropertiesService.cs
+++ b/samples/AvalonDraw/Services/PropertiesService.cs
@@ -85,9 +85,15 @@ public class PropertiesService
             AddTypographicAttribute(element, "font-feature-settings");
         }
 
-        if (element is SvgGradientServer grad)
+        if (element is SvgLinearGradientServer linGrad)
         {
-            var gEntry = new GradientStopsEntry(grad);
+            var gEntry = new GradientStopsEntry(linGrad);
+            gEntry.PropertyChanged += OnEntryChanged;
+            Properties.Add(gEntry);
+        }
+        else if (element is SvgRadialGradientServer radGrad)
+        {
+            var gEntry = new GradientStopsEntry(radGrad);
             gEntry.PropertyChanged += OnEntryChanged;
             Properties.Add(gEntry);
         }


### PR DESCRIPTION
## Summary
- extend GradientEditorWindow UI to switch gradient type and adjust radial settings
- create or modify SvgRadialGradientServer from gradient editor
- store edited gradient in GradientStopsEntry
- refresh PropertiesService for radial gradients
- update MainWindow integration

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release -p:EnableSourceLink=false`

------
https://chatgpt.com/codex/tasks/task_e_687abc8ce95c832190c3828111e7b1e1