### PR TITLE
Add color editing for gradient mesh

### DIFF
--- a/samples/AvalonDraw/GradientMeshEditorWindow.axaml
+++ b/samples/AvalonDraw/GradientMeshEditorWindow.axaml
@@ -3,15 +3,29 @@
         x:Class="AvalonDraw.GradientMeshEditorWindow"
         Width="400" Height="300"
         Title="Edit Gradient Mesh">
-    <Canvas x:Name="MeshCanvas" Background="Gray">
-        <ItemsControl ItemsSource="{Binding Points}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Ellipse Width="10" Height="10" Fill="Red"
-                             Canvas.Left="{Binding Position.X}"
-                             Canvas.Top="{Binding Position.Y}" />
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-    </Canvas>
+    <DockPanel Margin="10" LastChildFill="True">
+        <Canvas x:Name="MeshCanvas" Background="Gray" DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Points}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Canvas>
+                            <Ellipse Width="10" Height="10"
+                                     Fill="{Binding Color, Converter={StaticResource SkColorConverter}}"
+                                     Canvas.Left="{Binding Position.X}"
+                                     Canvas.Top="{Binding Position.Y}" />
+                            <ColorPicker Width="120"
+                                         Canvas.Left="{Binding Position.X}"
+                                         Canvas.Top="{Binding Position.Y}"
+                                         Color="{Binding Color, Mode=TwoWay, Converter={StaticResource SkColorConverter}}"
+                                         ColorChanged="ColorPicker_OnColorChanged" />
+                        </Canvas>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Canvas>
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Click="OkButton_OnClick" />
+            <Button Content="Cancel" Width="80" Click="CancelButton_OnClick" />
+        </StackPanel>
+    </DockPanel>
 </Window>

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -287,7 +287,14 @@ public partial class MainWindow : Window
                 btn.Click += async (_, _) =>
                 {
                     var dlg = new GradientMeshEditorWindow(meshEntry.Mesh);
-                    await dlg.ShowDialog(this);
+                    var result = await dlg.ShowDialog<bool>(this);
+                    if (result)
+                    {
+                        meshEntry.Mesh.Points.Clear();
+                        meshEntry.Mesh.Points.AddRange(dlg.Result.Points);
+                        meshEntry.UpdateValue();
+                        meshEntry.NotifyChanged();
+                    }
                 };
                 return btn;
             }

--- a/samples/AvalonDraw/Services/GradientMeshEntry.cs
+++ b/samples/AvalonDraw/Services/GradientMeshEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using Svg;
 using Svg.Model;
 
 namespace AvalonDraw.Services;
@@ -8,13 +9,24 @@ public class GradientMeshEntry : PropertyEntry
     public GradientMesh Mesh { get; }
 
     public GradientMeshEntry(GradientMesh mesh)
-        : base("Mesh", string.Empty, (_, __) => { })
+        : base("Mesh", mesh.ToString(), (_, __) => { })
     {
         Mesh = mesh;
     }
 
     public override void Apply(object target)
     {
-        // Placeholder for applying the mesh to an object.
+        if (target is SvgVisualElement element)
+            element.CustomAttributes["mesh"] = ToString();
+    }
+
+    public void UpdateValue()
+    {
+        Value = ToString();
+    }
+
+    public override string ToString()
+    {
+        return Mesh.ToString();
     }
 }

--- a/src/Svg.Model/GradientMesh.cs
+++ b/src/Svg.Model/GradientMesh.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using ShimSkiaSharp;
 
 namespace Svg.Model;
@@ -14,6 +16,42 @@ public sealed class GradientMesh
     /// List of mesh points.
     /// </summary>
     public List<GradientMeshPoint> Points { get; } = new();
+
+    public static GradientMesh Parse(string text)
+    {
+        var mesh = new GradientMesh();
+        if (string.IsNullOrWhiteSpace(text))
+            return mesh;
+
+        foreach (var part in text.Split(';'))
+        {
+            var items = part.Split(',');
+            if (items.Length != 6)
+                continue;
+
+            if (float.TryParse(items[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                float.TryParse(items[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) &&
+                byte.TryParse(items[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var r) &&
+                byte.TryParse(items[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var g) &&
+                byte.TryParse(items[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var b) &&
+                byte.TryParse(items[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var a))
+            {
+                mesh.Points.Add(new GradientMeshPoint(new SKPoint(x, y), new SKColor(r, g, b, a)));
+            }
+        }
+
+        return mesh;
+    }
+
+    public override string ToString()
+    {
+        var parts = new List<string>(Points.Count);
+        foreach (var p in Points)
+        {
+            parts.Add(FormattableString.Invariant($"{p.Position.X},{p.Position.Y},{p.Color.Red},{p.Color.Green},{p.Color.Blue},{p.Color.Alpha}"));
+        }
+        return string.Join(";", parts);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- support per-point colors in gradient mesh editor
- update gradient mesh entry serialization and apply logic
- ensure gradient mesh can parse/serialize color info
- hook editor results into property UI

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_687abc8d71a08321bbe11a30b458c8e1