### PR TITLE
Add browser-wasm SkiaSharp pin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,4 +43,9 @@
     <PackageVersion Include="Nuke.Common" Version="9.0.4" />
     <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.4" />
   </ItemGroup>
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+    <PackageVersion Update="SkiaSharp" Version="2.88.9" />
+    <PackageVersion Update="SkiaSharp.HarfBuzz" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- pin SkiaSharp packages to 2.88.9 when building for browser-wasm

## Testing
- `dotnet build Svg.Skia.sln -c Release`
- `dotnet test Svg.Skia.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687caab89bdc832198deed9db0b0f167