### PR TITLE
Update to version 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svg.Skia Changelog
 
+## 3.0.5
+
+* Updated Avalonia packages to 11.3.0.2.
+
 ## 0.3.0
 
 * Updated NuGet packages.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.4</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionPrefix>3.0.5</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <AvaloniaVersionPrefix>11.3.0.2</AvaloniaVersionPrefix>
     <AvaloniaVersionSuffix>$(VersionSuffix)</AvaloniaVersionSuffix>
     <Authors>Wiesław Šoltés</Authors>


### PR DESCRIPTION
## Summary
- bump library version to `3.0.5`
- document Avalonia update in CHANGELOG

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`

------
https://chatgpt.com/codex/tasks/task_e_687caabc42b48321bd3caa6ed38c7a7c