### PR TITLE
Fix null clip rect in generator

### DIFF
--- a/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
+++ b/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
@@ -708,7 +708,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {arithmeticImageFilter.EforcePMColor.ToBoolString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterBackground},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterForeground},");
-                sb.AppendLine($"{indent}    {arithmeticImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {arithmeticImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case BlendModeImageFilter blendModeImageFilter:
@@ -744,7 +744,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {blendModeImageFilter.Mode.ToSKBlendMode()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterBackground},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterForeground},");
-                sb.AppendLine($"{indent}    {blendModeImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {blendModeImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case BlurImageFilter blurImageFilter:
@@ -764,7 +764,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {blurImageFilter.SigmaX.ToFloatString()},");
                 sb.AppendLine($"{indent}    {blurImageFilter.SigmaY.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {blurImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {blurImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case ColorFilterImageFilter colorFilterImageFilter:
@@ -792,7 +792,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"SKImageFilter.CreateColorFilter(");
                 sb.AppendLine($"{indent}    {counter.ColorFilterVarName}{counterColorFilter},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {colorFilterImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {colorFilterImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case DilateImageFilter dilateImageFilter:
@@ -812,7 +812,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {dilateImageFilter.RadiusX.ToIntString()},");
                 sb.AppendLine($"{indent}    {dilateImageFilter.RadiusY.ToIntString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {dilateImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {dilateImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case DisplacementMapEffectImageFilter displacementMapEffectImageFilter:
@@ -843,7 +843,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {displacementMapEffectImageFilter.Scale.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterDisplacement},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {displacementMapEffectImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {displacementMapEffectImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case DistantLitDiffuseImageFilter distantLitDiffuseImageFilter:
@@ -865,7 +865,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {distantLitDiffuseImageFilter.SurfaceScale.ToFloatString()},");
                 sb.AppendLine($"{indent}    {distantLitDiffuseImageFilter.Kd.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {distantLitDiffuseImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {distantLitDiffuseImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case DistantLitSpecularImageFilter distantLitSpecularImageFilter:
@@ -888,7 +888,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {distantLitSpecularImageFilter.Ks.ToFloatString()},");
                 sb.AppendLine($"{indent}    {distantLitSpecularImageFilter.Shininess.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {distantLitSpecularImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {distantLitSpecularImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case ErodeImageFilter erodeImageFilter:
@@ -908,7 +908,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {erodeImageFilter.RadiusX.ToIntString()},");
                 sb.AppendLine($"{indent}    {erodeImageFilter.RadiusY.ToIntString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {erodeImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {erodeImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case ImageImageFilter imageImageFilter:
@@ -958,7 +958,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {matrixConvolutionImageFilter.TileMode.ToSKShaderTileMode()},");
                 sb.AppendLine($"{indent}    {matrixConvolutionImageFilter.ConvolveAlpha.ToBoolString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {matrixConvolutionImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {matrixConvolutionImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case MergeImageFilter mergeImageFilter:
@@ -991,7 +991,7 @@ public static class SkiaCSharpModelExtensions
                 sb.Append($"{indent}var {counter.ImageFilterVarName}{counterImageFilter} = ");
                 sb.AppendLine($"SKImageFilter.CreateMerge(");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}s{counterImageFilter},");
-                sb.AppendLine($"{indent}    {mergeImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {mergeImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case OffsetImageFilter offsetImageFilter:
@@ -1011,7 +1011,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {offsetImageFilter.Dx.ToFloatString()},");
                 sb.AppendLine($"{indent}    {offsetImageFilter.Dy.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {offsetImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {offsetImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case PaintImageFilter paintImageFilter:
@@ -1028,7 +1028,7 @@ public static class SkiaCSharpModelExtensions
                 sb.Append($"{indent}var {counter.ImageFilterVarName}{counterImageFilter} = ");
                 sb.AppendLine($"SKImageFilter.CreatePaint(");
                 sb.AppendLine($"{indent}    {counter.PaintVarName}{counterPaint},");
-                sb.AppendLine($"{indent}    {paintImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {paintImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
 
                 // NOTE: Do not dispose created SKTypeface by font manager.
 #if USE_DISPOSE_TYPEFACE
@@ -1075,7 +1075,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"SKImageFilter.CreateShader(");
                 sb.AppendLine($"{indent}    {counter.ShaderVarName}{counterShader},");
                 sb.AppendLine($"{indent}    {shaderImageFilter.Dither.ToBoolString()},");
-                sb.AppendLine($"{indent}    {shaderImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {shaderImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
 
                 sb.AppendLine($"{indent}{counter.ShaderVarName}{counterShader}?.Dispose();");
                 return;
@@ -1116,7 +1116,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {pointLitDiffuseImageFilter.SurfaceScale.ToFloatString()},");
                 sb.AppendLine($"{indent}    {pointLitDiffuseImageFilter.Kd.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {pointLitDiffuseImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {pointLitDiffuseImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case PointLitSpecularImageFilter pointLitSpecularImageFilter:
@@ -1139,7 +1139,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {pointLitSpecularImageFilter.Ks.ToFloatString()},");
                 sb.AppendLine($"{indent}    {pointLitSpecularImageFilter.Shininess.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {pointLitSpecularImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {pointLitSpecularImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case SpotLitDiffuseImageFilter spotLitDiffuseImageFilter:
@@ -1164,7 +1164,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {spotLitDiffuseImageFilter.SurfaceScale.ToFloatString()},");
                 sb.AppendLine($"{indent}    {spotLitDiffuseImageFilter.Kd.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {spotLitDiffuseImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {spotLitDiffuseImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case SpotLitSpecularImageFilter spotLitSpecularImageFilter:
@@ -1190,7 +1190,7 @@ public static class SkiaCSharpModelExtensions
                 sb.AppendLine($"{indent}    {spotLitSpecularImageFilter.Ks.ToFloatString()},");
                 sb.AppendLine($"{indent}    {spotLitSpecularImageFilter.SpecularExponent.ToFloatString()},");
                 sb.AppendLine($"{indent}    {counter.ImageFilterVarName}{counterImageFilterInput},");
-                sb.AppendLine($"{indent}    {spotLitSpecularImageFilter.Clip?.ToSKRect() ?? "null"});");
+                sb.AppendLine($"{indent}    {spotLitSpecularImageFilter.Clip?.ToSKRect() ?? "SKRect.Empty"});");
                 return;
             }
             case TileImageFilter tileImageFilter:


### PR DESCRIPTION
## Summary
- use `SKRect.Empty` when image filter clip is null
- regenerate sample using `svgc`

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_687caabcc8548321940616a292acc87a