### PR TITLE
Fix bitmap rounding and add small-scale test

### DIFF
--- a/src/Svg.Skia/SKPictureExtensions.cs
+++ b/src/Svg.Skia/SKPictureExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using System.IO;
 
 namespace Svg.Skia;
@@ -23,7 +24,9 @@ public static class SKPictureExtensions
         {
             return null;
         }
-        var skImageInfo = new SkiaSharp.SKImageInfo((int)width, (int)height, skColorType, skAlphaType, skColorSpace);
+        var widthRounded = Math.Max(1, (int)Math.Ceiling(width));
+        var heightRounded = Math.Max(1, (int)Math.Ceiling(height));
+        var skImageInfo = new SkiaSharp.SKImageInfo(widthRounded, heightRounded, skColorType, skAlphaType, skColorSpace);
         var skBitmap = new SkiaSharp.SKBitmap(skImageInfo);
         using var skCanvas = new SkiaSharp.SKCanvas(skBitmap);
         Draw(skPicture, background, scaleX, scaleY, skCanvas);

--- a/tests/Svg.Skia.UnitTests/ScaleBelowOneTests.cs
+++ b/tests/Svg.Skia.UnitTests/ScaleBelowOneTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using SkiaSharp;
+using Xunit;
+
+namespace Svg.Skia.UnitTests;
+
+public class ScaleBelowOneTests
+{
+    [Fact]
+    public void BitmapScale_BelowOne_ShouldNotBeEmpty()
+    {
+        const string svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"><rect width=\"10\" height=\"10\" fill=\"none\" stroke=\"black\"/></svg>";
+        var skSvg = SKSvg.CreateFromSvg(svg);
+
+        using var ms = new MemoryStream();
+        var saved = skSvg.Save(ms, SKColors.Transparent, scaleX: 0.05f, scaleY: 0.05f);
+        Assert.True(saved);
+
+        ms.Position = 0;
+        using var bitmap = SKBitmap.Decode(ms);
+        Assert.True(bitmap.Width > 0);
+        Assert.True(bitmap.Height > 0);
+
+        var visible = false;
+        for (var x = 0; x < bitmap.Width && !visible; x++)
+        {
+            for (var y = 0; y < bitmap.Height; y++)
+            {
+                if (bitmap.GetPixel(x, y).Alpha != 0)
+                {
+                    visible = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.True(visible);
+    }
+}
+


### PR DESCRIPTION
## Summary
- round bitmap dimensions when rendering SKPicture
- test converting small scaled SVG preserves visibility

## Testing
- `dotnet build Svg.Skia.sln -c Release /p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release /p:RepositoryUrl=https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_687caac3ffec8321b92106b4e2464900