### PR TITLE
Add symbol XML editor

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2580,13 +2580,18 @@ public partial class MainWindow : Window
             _pathService.Stop();
         if (_document is null)
             return;
-        var ids = _symbolService.Symbols
-            .Select(s => s.Symbol.ID)
-            .Where(id => !string.IsNullOrEmpty(id))
-            .ToList();
-        if (ids.Count == 0)
+        if (_symbolService.Symbols.Count == 0)
             return;
-        var win = new SymbolSelectWindow(ids!);
+        var win = new SymbolSelectWindow(_symbolService);
+        win.SymbolEdited += (_, _) =>
+        {
+            if (_document is { })
+            {
+                SvgView.SkSvg!.FromSvgDocument(_document);
+                UpdateSymbols();
+                SvgView.InvalidateVisual();
+            }
+        };
         var result = await win.ShowDialog<string?>(this);
         if (result is null)
             return;

--- a/samples/AvalonDraw/SymbolEditorWindow.axaml
+++ b/samples/AvalonDraw/SymbolEditorWindow.axaml
@@ -1,10 +1,10 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="AvalonDraw.SymbolSelectWindow"
-        Width="300" Height="200"
-        Title="Select Symbol">
+        x:Class="AvalonDraw.SymbolEditorWindow"
+        Width="600" Height="400"
+        Title="Edit Symbol XML">
     <StackPanel Margin="10" Spacing="4">
-        <AutoCompleteBox x:Name="SymbolList" MinimumPrefixLength="0" GotFocus="SymbolList_OnGotFocus" DoubleTapped="SymbolList_OnDoubleTapped" />
+        <TextBox x:Name="Editor" AcceptsReturn="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
             <Button Content="OK" Width="80" Click="OkButton_OnClick"/>
             <Button Content="Cancel" Width="80" Click="CancelButton_OnClick"/>

--- a/samples/AvalonDraw/SymbolEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/SymbolEditorWindow.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AvalonDraw;
+
+public partial class SymbolEditorWindow : Window
+{
+    private readonly TextBox _editor;
+
+    public SymbolEditorWindow(string xml)
+    {
+        InitializeComponent();
+        _editor = this.FindControl<TextBox>("Editor");
+        _editor.Text = xml;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public string Result { get; private set; } = string.Empty;
+
+    private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Result = _editor.Text;
+        Close(true);
+    }
+
+    private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/samples/AvalonDraw/SymbolSelectWindow.axaml.cs
+++ b/samples/AvalonDraw/SymbolSelectWindow.axaml.cs
@@ -1,21 +1,31 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
 using Avalonia.Input;
+using AvalonDraw.Services;
+using Svg;
+using Svg.Model.Services;
 
 namespace AvalonDraw;
 
 public partial class SymbolSelectWindow : Window
 {
     private readonly AutoCompleteBox _list;
+    private readonly SymbolService _service;
 
-    public SymbolSelectWindow(IEnumerable<string> ids)
+    public SymbolSelectWindow(SymbolService service)
     {
         InitializeComponent();
+        _service = service;
         _list = this.FindControl<AutoCompleteBox>("SymbolList");
-        _list.ItemsSource = ids;
+        _list.ItemsSource = service.Symbols
+            .Select(s => s.Symbol.ID)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToList();
     }
 
     private void InitializeComponent()
@@ -40,5 +50,31 @@ public partial class SymbolSelectWindow : Window
     {
         if (_list is AutoCompleteBox box)
             box.IsDropDownOpen = true;
+    }
+
+    public event EventHandler? SymbolEdited;
+
+    private async void SymbolList_OnDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (_list.SelectedItem is not string id)
+            return;
+        var symbol = _service.Find(id);
+        if (symbol is null)
+            return;
+        var win = new SymbolEditorWindow(symbol.GetXML());
+        var ok = await win.ShowDialog<bool>(this);
+        if (!ok)
+            return;
+        var wrapper = $"<svg xmlns='http://www.w3.org/2000/svg'><defs>{win.Result}</defs></svg>";
+        var doc = SvgService.FromSvg(wrapper);
+        var newSym = doc?.Children.OfType<SvgDefinitionList>()
+            .SelectMany(d => d.Children.OfType<SvgSymbol>())
+            .FirstOrDefault();
+        if (newSym is null)
+            return;
+        if (string.IsNullOrEmpty(newSym.ID))
+            newSym.ID = id;
+        _service.ReplaceSymbol(symbol, newSym);
+        SymbolEdited?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
## Summary
- allow editing symbol XML directly
- open editor by double-clicking in symbol selection
- update symbol service to replace definitions
- refresh drawing when symbol edits are saved

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`
- `dotnet test Svg.Skia.sln -c Release -p:RepositoryUrl=https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_687caab3628883218bb7176f97457642