### PR TITLE
Ensure Svg asset loaders survive iOS linking

### DIFF
--- a/samples/svgc/ImageSharpAssetLoader.cs
+++ b/samples/svgc/ImageSharpAssetLoader.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
+using Svg.Model;
 
 namespace svgc;
 
+[Preserve(AllMembers = true)]
 internal class ImageSharpAssetLoader : Svg.Model.ISvgAssetLoader
 {
     public ShimSkiaSharp.SKImage LoadImage(Stream stream)

--- a/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
@@ -6,12 +6,14 @@ using AMI = Avalonia.Media.Imaging;
 using SM = Svg.Model;
 using Avalonia.Media;
 using System.Collections.Generic;
+using Svg.Model;
 
 namespace Avalonia.Svg;
 
 /// <summary>
 /// Asset loader implementation using Avalonia types.
 /// </summary>
+[Preserve(AllMembers = true)]
 public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
 {
     /// <inheritdoc />

--- a/src/Svg.Model/PreserveAttribute.cs
+++ b/src/Svg.Model/PreserveAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Svg.Model;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event, Inherited = false)]
+public sealed class PreserveAttribute : Attribute
+{
+    public bool AllMembers { get; set; }
+    public bool Conditional { get; set; }
+}
+

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using Svg.Model;
 
 namespace Svg.Skia;
 
 /// <summary>
 /// Asset loader implementation using SkiaSharp types.
 /// </summary>
+[Preserve(AllMembers = true)]
 public class SkiaSvgAssetLoader : Model.ISvgAssetLoader
 {
     private readonly SkiaModel _skiaModel;

--- a/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
+++ b/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using Svg.Model;
 
 namespace Svg.SourceGenerator.Skia;
 
+[Preserve(AllMembers = true)]
 public class SkiaGeneratorSvgAssetLoader : Model.ISvgAssetLoader
 {
     public ShimSkiaSharp.SKImage LoadImage(System.IO.Stream stream)


### PR DESCRIPTION
## Summary
- add `PreserveAttribute` to Svg.Model
- mark Svg asset loaders with `[Preserve]`

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release --no-build`
- `dotnet workload install ios` *(fails: Workload ID ios isn't supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_687caabe0d748321ae95c38515c3c532