### PR TITLE
Add text orientation and warp controls

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -2219,7 +2219,8 @@ public partial class MainWindow : Window
         if (_document is null)
             return;
         var win = new TextEditorWindow(_document.GetXML(), _toolService.CurrentFontFamily,
-            _toolService.CurrentFontWeight, _toolService.CurrentLetterSpacing, _toolService.CurrentWordSpacing);
+            _toolService.CurrentFontWeight, _toolService.CurrentLetterSpacing, _toolService.CurrentWordSpacing,
+            0f, SvgTextPathMethod.Align);
         var ok = await win.ShowDialog<bool>(this);
         if (ok)
         {
@@ -2234,12 +2235,16 @@ public partial class MainWindow : Window
     {
         if (_selectedSvgElement is SvgTextBase txt && _document is { })
         {
+            float.TryParse(txt.Rotate, out var orient);
+            var method = txt is SvgTextPath tp ? tp.Method : SvgTextPathMethod.Align;
             var win = new TextEditorWindow(
                 txt.Text,
                 txt.FontFamily,
                 txt.FontWeight,
                 txt.LetterSpacing.Value,
-                txt.WordSpacing.Value);
+                txt.WordSpacing.Value,
+                orient,
+                method);
             var ok2 = await win.ShowDialog<bool>(this);
             if (ok2)
             {
@@ -2249,6 +2254,9 @@ public partial class MainWindow : Window
                 txt.FontWeight = win.FontWeightResult;
                 txt.LetterSpacing = new SvgUnit(SvgUnitType.User, win.LetterSpacingResult);
                 txt.WordSpacing = new SvgUnit(SvgUnitType.User, win.WordSpacingResult);
+                txt.Rotate = win.OrientationResult.ToString();
+                if (txt is SvgTextPath tp2)
+                    tp2.Method = win.WarpResult;
                 SvgView.SkSvg!.FromSvgDocument(_document);
                 UpdateSelectedDrawable();
                 LoadProperties(txt);

--- a/samples/AvalonDraw/TextEditorWindow.axaml
+++ b/samples/AvalonDraw/TextEditorWindow.axaml
@@ -12,6 +12,13 @@
             <TextBox x:Name="LetterBox" Width="60" />
             <TextBlock Text="Word" VerticalAlignment="Center" />
             <TextBox x:Name="WordBox" Width="60" />
+            <TextBlock Text="Orientation" VerticalAlignment="Center" />
+            <TextBox x:Name="OrientationBox" Width="60" />
+            <TextBlock Text="Warp" VerticalAlignment="Center" />
+            <ComboBox x:Name="WarpBox" Width="80">
+                <ComboBoxItem Content="Align" />
+                <ComboBoxItem Content="Stretch" />
+            </ComboBox>
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
             <Button Content="OK" Click="OkButton_OnClick" Width="80"/>

--- a/samples/AvalonDraw/TextEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/TextEditorWindow.axaml.cs
@@ -15,8 +15,10 @@ public partial class TextEditorWindow : Window
     private readonly ComboBox _fontWeightBox;
     private readonly TextBox _letterBox;
     private readonly TextBox _wordBox;
+    private readonly TextBox _orientationBox;
+    private readonly ComboBox _warpBox;
 
-    public TextEditorWindow(string text, string fontFamily, SvgFontWeight weight, float letter, float word)
+    public TextEditorWindow(string text, string fontFamily, SvgFontWeight weight, float letter, float word, float orientation, SvgTextPathMethod warp)
     {
         InitializeComponent();
         _editor = this.FindControl<TextBox>("Editor");
@@ -24,6 +26,8 @@ public partial class TextEditorWindow : Window
         _fontWeightBox = this.FindControl<ComboBox>("FontWeightBox");
         _letterBox = this.FindControl<TextBox>("LetterBox");
         _wordBox = this.FindControl<TextBox>("WordBox");
+        _orientationBox = this.FindControl<TextBox>("OrientationBox");
+        _warpBox = this.FindControl<ComboBox>("WarpBox");
 
         _editor.Text = text;
         _fontFamilyBox.ItemsSource = FontManager.Current?.SystemFonts;
@@ -32,6 +36,8 @@ public partial class TextEditorWindow : Window
         _fontWeightBox.SelectedItem = ToFontWeight(weight);
         _letterBox.Text = letter.ToString();
         _wordBox.Text = word.ToString();
+        _orientationBox.Text = orientation.ToString();
+        _warpBox.SelectedIndex = warp == SvgTextPathMethod.Stretch ? 1 : 0;
     }
 
     private static FontWeight ToFontWeight(SvgFontWeight w) => w switch
@@ -73,6 +79,8 @@ public partial class TextEditorWindow : Window
     public SvgFontWeight FontWeightResult { get; private set; }
     public float LetterSpacingResult { get; private set; }
     public float WordSpacingResult { get; private set; }
+    public float OrientationResult { get; private set; }
+    public SvgTextPathMethod WarpResult { get; private set; }
 
     private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
@@ -81,8 +89,11 @@ public partial class TextEditorWindow : Window
         FontWeightResult = FromFontWeight((FontWeight)_fontWeightBox.SelectedItem!);
         float.TryParse(_letterBox.Text, out var ls);
         float.TryParse(_wordBox.Text, out var ws);
+        float.TryParse(_orientationBox.Text, out var or);
         LetterSpacingResult = ls;
         WordSpacingResult = ws;
+        OrientationResult = or;
+        WarpResult = _warpBox.SelectedIndex == 1 ? SvgTextPathMethod.Stretch : SvgTextPathMethod.Align;
         Close(true);
     }
 


### PR DESCRIPTION
## Summary
- update text editor UI with orientation and warp fields
- capture orientation/warp in TextEditorWindow
- apply orientation/warp in MainWindow when editing text

## Testing
- `dotnet format samples/AvalonDraw/AvalonDraw.csproj --no-restore`
- `dotnet build samples/AvalonDraw/AvalonDraw.csproj -c Release /p:EnableSourceLink=false /p:ContinuousIntegrationBuild=false`

------
https://chatgpt.com/codex/tasks/task_e_687caab24c748321a67419fd364d712c