### PR TITLE
Add radial gradient editing

### DIFF
--- a/samples/AvalonDraw/GradientEditorWindow.axaml
+++ b/samples/AvalonDraw/GradientEditorWindow.axaml
@@ -4,6 +4,23 @@
         Width="400" Height="300"
         Title="Edit Gradient">
     <DockPanel Margin="10" LastChildFill="True">
+        <StackPanel DockPanel.Dock="Top" Orientation="Vertical" Spacing="4">
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="Type:" VerticalAlignment="Center"/>
+                <ComboBox x:Name="TypeBox" Width="100">
+                    <ComboBoxItem Content="Linear"/>
+                    <ComboBoxItem Content="Radial"/>
+                </ComboBox>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="cx:" VerticalAlignment="Center"/>
+                <TextBox x:Name="CenterXBox" Width="60"/>
+                <TextBlock Text="cy:" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                <TextBox x:Name="CenterYBox" Width="60"/>
+                <TextBlock Text="r:" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                <TextBox x:Name="RadiusBox" Width="60"/>
+            </StackPanel>
+        </StackPanel>
         <DataGrid x:Name="StopsGrid" DockPanel.Dock="Top" AutoGenerateColumns="False">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Offset" Binding="{Binding Offset, Mode=TwoWay}" Width="80"/>

--- a/samples/AvalonDraw/GradientEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/GradientEditorWindow.axaml.cs
@@ -1,10 +1,11 @@
 using System.Collections.ObjectModel;
 using System.Linq;
+using AvalonDraw.Services;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
-using AvalonDraw.Services;
+using Avalonia.Markup.Xaml;
+using Svg;
 
 namespace AvalonDraw;
 
@@ -12,14 +13,39 @@ public partial class GradientEditorWindow : Window
 {
     private readonly DataGrid _grid;
     private readonly ObservableCollection<GradientStopInfo> _stops;
+    private readonly ComboBox _typeBox;
+    private readonly TextBox _centerXBox;
+    private readonly TextBox _centerYBox;
+    private readonly TextBox _radiusBox;
+    private readonly SvgGradientServer? _gradient;
 
-    public GradientEditorWindow(ObservableCollection<GradientStopInfo> stops)
+    public GradientEditorWindow(ObservableCollection<GradientStopInfo> stops, SvgGradientServer? gradient = null)
     {
         InitializeComponent();
         Resources["ColorStringConverter"] = new ColorStringConverter();
         _grid = this.FindControl<DataGrid>("StopsGrid");
+        _typeBox = this.FindControl<ComboBox>("TypeBox");
+        _centerXBox = this.FindControl<TextBox>("CenterXBox");
+        _centerYBox = this.FindControl<TextBox>("CenterYBox");
+        _radiusBox = this.FindControl<TextBox>("RadiusBox");
+        _gradient = gradient;
         _stops = new ObservableCollection<GradientStopInfo>(stops.Select(s => new GradientStopInfo { Offset = s.Offset, Color = s.Color }));
         _grid.ItemsSource = _stops;
+
+        if (gradient is SvgRadialGradientServer rad)
+        {
+            _typeBox.SelectedIndex = 1;
+            _centerXBox.Text = rad.CenterX.ToString();
+            _centerYBox.Text = rad.CenterY.ToString();
+            _radiusBox.Text = rad.Radius.ToString();
+        }
+        else
+        {
+            _typeBox.SelectedIndex = 0;
+            _centerXBox.Text = "50%";
+            _centerYBox.Text = "50%";
+            _radiusBox.Text = "50%";
+        }
     }
 
     private void InitializeComponent()
@@ -28,6 +54,8 @@ public partial class GradientEditorWindow : Window
     }
 
     public ObservableCollection<GradientStopInfo> Result { get; private set; } = new();
+    public SvgRadialGradientServer? ResultRadial { get; private set; }
+    public bool IsRadial => _typeBox.SelectedIndex == 1;
 
     private void AddButton_OnClick(object? sender, RoutedEventArgs e)
     {
@@ -43,6 +71,20 @@ public partial class GradientEditorWindow : Window
     private void OkButton_OnClick(object? sender, RoutedEventArgs e)
     {
         Result = new ObservableCollection<GradientStopInfo>(_stops.Select(s => new GradientStopInfo { Offset = s.Offset, Color = s.Color }));
+        if (IsRadial)
+        {
+            var rad = _gradient as SvgRadialGradientServer ?? new SvgRadialGradientServer();
+            try
+            { rad.CenterX = SvgUnitConverter.Parse(_centerXBox.Text); }
+            catch { }
+            try
+            { rad.CenterY = SvgUnitConverter.Parse(_centerYBox.Text); }
+            catch { }
+            try
+            { rad.Radius = SvgUnitConverter.Parse(_radiusBox.Text); }
+            catch { }
+            ResultRadial = rad;
+        }
         Close(true);
     }
 

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -296,10 +296,27 @@ public partial class MainWindow : Window
                 var btn = new Button { Content = entry.Value ?? "Edit", VerticalAlignment = VerticalAlignment.Center };
                 btn.Click += async (_, _) =>
                 {
-                    var dlg = new GradientEditorWindow(gEntry.Stops);
+                    var dlg = new GradientEditorWindow(gEntry.Stops, _selectedSvgElement as SvgGradientServer);
                     var result = await dlg.ShowDialog<bool>(this);
                     if (result)
                     {
+                        if (dlg.ResultRadial is { } radial && _selectedSvgElement is SvgGradientServer grad)
+                        {
+                            radial.ID = grad.ID;
+                            radial.GradientUnits = grad.GradientUnits;
+                            radial.SpreadMethod = grad.SpreadMethod;
+                            radial.GradientTransform = grad.GradientTransform;
+                            radial.InheritGradient = grad.InheritGradient;
+                            if (grad.Parent is SvgElement parent)
+                            {
+                                var idx = parent.Children.IndexOf(grad);
+                                if (idx >= 0)
+                                    parent.Children[idx] = radial;
+                            }
+                            _selectedSvgElement = radial;
+                            LoadProperties(_selectedSvgElement);
+                        }
+
                         gEntry.Stops.Clear();
                         foreach (var s in dlg.Result)
                             gEntry.Stops.Add(s);


### PR DESCRIPTION
## Summary
- support switching between linear and radial gradients in GradientEditorWindow
- bind radial gradient center and radius inputs
- update gradient editing logic to create SvgRadialGradientServer when needed

## Testing
- `dotnet build samples/AvalonDraw/AvalonDraw.csproj -c Release -p:EnableSourceLink=false`


------
https://chatgpt.com/codex/tasks/task_e_687caab1b5a48321a6bcf797b78fe09f