### PR TITLE
Support text decoration lines

### DIFF
--- a/samples/svgc/ImageSharpAssetLoader.cs
+++ b/samples/svgc/ImageSharpAssetLoader.cs
@@ -9,7 +9,7 @@ internal class ImageSharpAssetLoader : Svg.Model.ISvgAssetLoader
     {
         var data = ShimSkiaSharp.SKImage.FromStream(stream);
         using var image = SixLabors.ImageSharp.Image.Load(data);
-        return new ShimSkiaSharp.SKImage {Data = data, Width = image.Width, Height = image.Height};
+        return new ShimSkiaSharp.SKImage { Data = data, Width = image.Width, Height = image.Height };
     }
 
     public List<Svg.Model.TypefaceSpan> FindTypefaces(string? text, ShimSkiaSharp.SKPaint paintPreferredTypeface)
@@ -38,7 +38,11 @@ internal class ImageSharpAssetLoader : Svg.Model.ISvgAssetLoader
             Descent = size * 0.2f,
             Top = -size * 0.8f,
             Bottom = size * 0.2f,
-            Leading = 0f
+            Leading = 0f,
+            UnderlinePosition = 0f,
+            UnderlineThickness = 0f,
+            StrikeoutPosition = 0f,
+            StrikeoutThickness = 0f
         };
     }
 

--- a/src/ShimSkiaSharp/SKCanvas.cs
+++ b/src/ShimSkiaSharp/SKCanvas.cs
@@ -15,6 +15,8 @@ public record DrawImageCanvasCommand(SKImage? Image, SKRect Source, SKRect Dest,
 
 public record DrawPathCanvasCommand(SKPath? Path, SKPaint? Paint) : CanvasCommand;
 
+public record DrawLineCanvasCommand(float X0, float Y0, float X1, float Y1, SKPaint Paint) : CanvasCommand;
+
 public record DrawTextBlobCanvasCommand(SKTextBlob? TextBlob, float X, float Y, SKPaint? Paint) : CanvasCommand;
 
 public record DrawTextCanvasCommand(string Text, float X, float Y, SKPaint? Paint) : CanvasCommand;
@@ -62,6 +64,11 @@ public class SKCanvas
     public void DrawPath(SKPath path, SKPaint paint)
     {
         Commands?.Add(new DrawPathCanvasCommand(path, paint));
+    }
+
+    public void DrawLine(float x0, float y0, float x1, float y1, SKPaint paint)
+    {
+        Commands?.Add(new DrawLineCanvasCommand(x0, y0, x1, y1, paint));
     }
 
     public void DrawText(SKTextBlob textBlob, float x, float y, SKPaint paint)

--- a/src/ShimSkiaSharp/SKFontMetrics.cs
+++ b/src/ShimSkiaSharp/SKFontMetrics.cs
@@ -7,4 +7,8 @@ public struct SKFontMetrics
     public float Descent { get; set; }
     public float Bottom { get; set; }
     public float Leading { get; set; }
+    public float UnderlinePosition { get; set; }
+    public float UnderlineThickness { get; set; }
+    public float StrikeoutPosition { get; set; }
+    public float StrikeoutThickness { get; set; }
 }

--- a/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaSvgAssetLoader.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Collections.Generic;
 using System.IO;
+using Avalonia.Media;
 using ShimSkiaSharp;
 using AMI = Avalonia.Media.Imaging;
 using SM = Svg.Model;
-using Avalonia.Media;
-using System.Collections.Generic;
 
 namespace Avalonia.Svg;
 
@@ -19,7 +19,7 @@ public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
     {
         var data = SKImage.FromStream(stream);
         using var image = new AMI.Bitmap(stream);
-        return new SKImage {Data = data, Width = (float)image.Size.Width, Height = (float)image.Size.Height};
+        return new SKImage { Data = data, Width = (float)image.Size.Width, Height = (float)image.Size.Height };
     }
 
     /// <inheritdoc />
@@ -47,8 +47,8 @@ public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
                     slant,
                     weight,
                     width,
-                    preferredTypeface.FamilyName is { } n 
-                        ? FontFamily.Parse(n) 
+                    preferredTypeface.FamilyName is { } n
+                        ? FontFamily.Parse(n)
                         : null,
                     null, out var typeface);
 
@@ -104,8 +104,8 @@ public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
             {
                 runningTypeface = typeface;
             }
-            else if (runningTypeface is null && typeface is { } 
-                     || runningTypeface is { } && typeface is null 
+            else if (runningTypeface is null && typeface is { }
+                     || runningTypeface is { } && typeface is null
                      || runningTypeface != typeface)
             {
                 YieldCurrentTypefaceText();
@@ -140,7 +140,11 @@ public class AvaloniaSvgAssetLoader : SM.ISvgAssetLoader
             Ascent = -(float)(metrics.Ascent * paint.TextSize),
             Descent = (float)(metrics.Descent * paint.TextSize),
             Bottom = (float)(metrics.Descent * paint.TextSize),
-            Leading = (float)(metrics.LineGap * paint.TextSize)
+            Leading = (float)(metrics.LineGap * paint.TextSize),
+            UnderlinePosition = 0f,
+            UnderlineThickness = 0f,
+            StrikeoutPosition = 0f,
+            StrikeoutThickness = 0f
         };
     }
 

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -181,7 +181,8 @@ public class SkiaModel
 
     public SkiaSharp.SKTypeface? ToSKTypeface(SKTypeface? typeface)
     {
-        if (typeface is null || typeface.FamilyName is null) return SkiaSharp.SKTypeface.Default;
+        if (typeface is null || typeface.FamilyName is null)
+            return SkiaSharp.SKTypeface.Default;
 
         var fontFamily = typeface.FamilyName;
         var fontWeight = ToSKFontStyleWeight(typeface.FontWeight);
@@ -254,22 +255,34 @@ public class SkiaModel
         switch (shader)
         {
             case ColorShader colorShader:
-            {
-                return SkiaSharp.SKShader.CreateColor(
-                    ToSKColor(colorShader.Color),
-                    colorShader.ColorSpace == SKColorSpace.Srgb 
-                        ? Settings.Srgb 
-                        : Settings.SrgbLinear);
-            }
-            case LinearGradientShader linearGradientShader:
-            {
-                if (linearGradientShader.Colors is null || linearGradientShader.ColorPos is null)
                 {
-                    return null;
+                    return SkiaSharp.SKShader.CreateColor(
+                        ToSKColor(colorShader.Color),
+                        colorShader.ColorSpace == SKColorSpace.Srgb
+                            ? Settings.Srgb
+                            : Settings.SrgbLinear);
                 }
-
-                if (linearGradientShader.LocalMatrix is { })
+            case LinearGradientShader linearGradientShader:
                 {
+                    if (linearGradientShader.Colors is null || linearGradientShader.ColorPos is null)
+                    {
+                        return null;
+                    }
+
+                    if (linearGradientShader.LocalMatrix is { })
+                    {
+                        return SkiaSharp.SKShader.CreateLinearGradient(
+                            ToSKPoint(linearGradientShader.Start),
+                            ToSKPoint(linearGradientShader.End),
+                            ToSKColors(linearGradientShader.Colors),
+                            linearGradientShader.ColorSpace == SKColorSpace.Srgb
+                                ? Settings.Srgb
+                                : Settings.SrgbLinear,
+                            linearGradientShader.ColorPos,
+                            ToSKShaderTileMode(linearGradientShader.Mode),
+                            ToSKMatrix(linearGradientShader.LocalMatrix.Value));
+                    }
+
                     return SkiaSharp.SKShader.CreateLinearGradient(
                         ToSKPoint(linearGradientShader.Start),
                         ToSKPoint(linearGradientShader.End),
@@ -278,29 +291,29 @@ public class SkiaModel
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
                         linearGradientShader.ColorPos,
-                        ToSKShaderTileMode(linearGradientShader.Mode),
-                        ToSKMatrix(linearGradientShader.LocalMatrix.Value));
+                        ToSKShaderTileMode(linearGradientShader.Mode));
                 }
-
-                return SkiaSharp.SKShader.CreateLinearGradient(
-                    ToSKPoint(linearGradientShader.Start),
-                    ToSKPoint(linearGradientShader.End),
-                    ToSKColors(linearGradientShader.Colors),
-                    linearGradientShader.ColorSpace == SKColorSpace.Srgb 
-                        ? Settings.Srgb 
-                        : Settings.SrgbLinear,
-                    linearGradientShader.ColorPos,
-                    ToSKShaderTileMode(linearGradientShader.Mode));
-            }
             case RadialGradientShader radialGradientShader:
-            {
-                if (radialGradientShader.Colors is null || radialGradientShader.ColorPos is null)
                 {
-                    return null;
-                }
+                    if (radialGradientShader.Colors is null || radialGradientShader.ColorPos is null)
+                    {
+                        return null;
+                    }
 
-                if (radialGradientShader.LocalMatrix is { })
-                {
+                    if (radialGradientShader.LocalMatrix is { })
+                    {
+                        return SkiaSharp.SKShader.CreateRadialGradient(
+                            ToSKPoint(radialGradientShader.Center),
+                            radialGradientShader.Radius,
+                            ToSKColors(radialGradientShader.Colors),
+                            radialGradientShader.ColorSpace == SKColorSpace.Srgb
+                                ? Settings.Srgb
+                                : Settings.SrgbLinear,
+                            radialGradientShader.ColorPos,
+                            ToSKShaderTileMode(radialGradientShader.Mode),
+                            ToSKMatrix(radialGradientShader.LocalMatrix.Value));
+                    }
+
                     return SkiaSharp.SKShader.CreateRadialGradient(
                         ToSKPoint(radialGradientShader.Center),
                         radialGradientShader.Radius,
@@ -309,29 +322,31 @@ public class SkiaModel
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
                         radialGradientShader.ColorPos,
-                        ToSKShaderTileMode(radialGradientShader.Mode),
-                        ToSKMatrix(radialGradientShader.LocalMatrix.Value));
+                        ToSKShaderTileMode(radialGradientShader.Mode));
                 }
-
-                return SkiaSharp.SKShader.CreateRadialGradient(
-                    ToSKPoint(radialGradientShader.Center),
-                    radialGradientShader.Radius,
-                    ToSKColors(radialGradientShader.Colors),
-                    radialGradientShader.ColorSpace == SKColorSpace.Srgb 
-                        ? Settings.Srgb 
-                        : Settings.SrgbLinear,
-                    radialGradientShader.ColorPos,
-                    ToSKShaderTileMode(radialGradientShader.Mode));
-            }
             case TwoPointConicalGradientShader twoPointConicalGradientShader:
-            {
-                if (twoPointConicalGradientShader.Colors is null || twoPointConicalGradientShader.ColorPos is null)
                 {
-                    return null;
-                }
+                    if (twoPointConicalGradientShader.Colors is null || twoPointConicalGradientShader.ColorPos is null)
+                    {
+                        return null;
+                    }
 
-                if (twoPointConicalGradientShader.LocalMatrix is { })
-                {
+                    if (twoPointConicalGradientShader.LocalMatrix is { })
+                    {
+                        return SkiaSharp.SKShader.CreateTwoPointConicalGradient(
+                            ToSKPoint(twoPointConicalGradientShader.Start),
+                            twoPointConicalGradientShader.StartRadius,
+                            ToSKPoint(twoPointConicalGradientShader.End),
+                            twoPointConicalGradientShader.EndRadius,
+                            ToSKColors(twoPointConicalGradientShader.Colors),
+                            twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb
+                                ? Settings.Srgb
+                                : Settings.SrgbLinear,
+                            twoPointConicalGradientShader.ColorPos,
+                            ToSKShaderTileMode(twoPointConicalGradientShader.Mode),
+                            ToSKMatrix(twoPointConicalGradientShader.LocalMatrix.Value));
+                    }
+
                     return SkiaSharp.SKShader.CreateTwoPointConicalGradient(
                         ToSKPoint(twoPointConicalGradientShader.Start),
                         twoPointConicalGradientShader.StartRadius,
@@ -342,54 +357,40 @@ public class SkiaModel
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
                         twoPointConicalGradientShader.ColorPos,
-                        ToSKShaderTileMode(twoPointConicalGradientShader.Mode),
-                        ToSKMatrix(twoPointConicalGradientShader.LocalMatrix.Value));
+                        ToSKShaderTileMode(twoPointConicalGradientShader.Mode));
                 }
-
-                return SkiaSharp.SKShader.CreateTwoPointConicalGradient(
-                    ToSKPoint(twoPointConicalGradientShader.Start),
-                    twoPointConicalGradientShader.StartRadius,
-                    ToSKPoint(twoPointConicalGradientShader.End),
-                    twoPointConicalGradientShader.EndRadius,
-                    ToSKColors(twoPointConicalGradientShader.Colors),
-                    twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb 
-                        ? Settings.Srgb 
-                        : Settings.SrgbLinear,
-                    twoPointConicalGradientShader.ColorPos,
-                    ToSKShaderTileMode(twoPointConicalGradientShader.Mode));
-            }
             case PictureShader pictureShader:
-            {
-                if (pictureShader.Src is null)
                 {
-                    return null;
-                }
+                    if (pictureShader.Src is null)
+                    {
+                        return null;
+                    }
 
-                return SkiaSharp.SKShader.CreatePicture(
-                    ToSKPicture(pictureShader.Src),
-                    SkiaSharp.SKShaderTileMode.Repeat,
-                    SkiaSharp.SKShaderTileMode.Repeat,
-                    ToSKMatrix(pictureShader.LocalMatrix),
-                    ToSKRect(pictureShader.Tile));
-            }
+                    return SkiaSharp.SKShader.CreatePicture(
+                        ToSKPicture(pictureShader.Src),
+                        SkiaSharp.SKShaderTileMode.Repeat,
+                        SkiaSharp.SKShaderTileMode.Repeat,
+                        ToSKMatrix(pictureShader.LocalMatrix),
+                        ToSKRect(pictureShader.Tile));
+                }
             case PerlinNoiseFractalNoiseShader perlinNoiseFractalNoiseShader:
-            {
-                return SkiaSharp.SKShader.CreatePerlinNoiseFractalNoise(
-                    perlinNoiseFractalNoiseShader.BaseFrequencyX,
-                    perlinNoiseFractalNoiseShader.BaseFrequencyY,
-                    perlinNoiseFractalNoiseShader.NumOctaves,
-                    perlinNoiseFractalNoiseShader.Seed,
-                    ToSKPointI(perlinNoiseFractalNoiseShader.TileSize));
-            }
+                {
+                    return SkiaSharp.SKShader.CreatePerlinNoiseFractalNoise(
+                        perlinNoiseFractalNoiseShader.BaseFrequencyX,
+                        perlinNoiseFractalNoiseShader.BaseFrequencyY,
+                        perlinNoiseFractalNoiseShader.NumOctaves,
+                        perlinNoiseFractalNoiseShader.Seed,
+                        ToSKPointI(perlinNoiseFractalNoiseShader.TileSize));
+                }
             case PerlinNoiseTurbulenceShader perlinNoiseTurbulenceShader:
-            {
-                return SkiaSharp.SKShader.CreatePerlinNoiseTurbulence(
-                    perlinNoiseTurbulenceShader.BaseFrequencyX,
-                    perlinNoiseTurbulenceShader.BaseFrequencyY,
-                    perlinNoiseTurbulenceShader.NumOctaves,
-                    perlinNoiseTurbulenceShader.Seed,
-                    ToSKPointI(perlinNoiseTurbulenceShader.TileSize));
-            }
+                {
+                    return SkiaSharp.SKShader.CreatePerlinNoiseTurbulence(
+                        perlinNoiseTurbulenceShader.BaseFrequencyX,
+                        perlinNoiseTurbulenceShader.BaseFrequencyY,
+                        perlinNoiseTurbulenceShader.NumOctaves,
+                        perlinNoiseTurbulenceShader.Seed,
+                        ToSKPointI(perlinNoiseTurbulenceShader.TileSize));
+                }
             default:
                 return null;
         }
@@ -400,42 +401,42 @@ public class SkiaModel
         switch (colorFilter)
         {
             case BlendModeColorFilter blendModeColorFilter:
-            {
-                return SkiaSharp.SKColorFilter.CreateBlendMode(
-                    ToSKColor(blendModeColorFilter.Color),
-                    ToSKBlendMode(blendModeColorFilter.Mode));
-            }
+                {
+                    return SkiaSharp.SKColorFilter.CreateBlendMode(
+                        ToSKColor(blendModeColorFilter.Color),
+                        ToSKBlendMode(blendModeColorFilter.Mode));
+                }
             case ColorMatrixColorFilter colorMatrixColorFilter:
-            {
-                if (colorMatrixColorFilter.Matrix is null)
                 {
-                    return null;
+                    if (colorMatrixColorFilter.Matrix is null)
+                    {
+                        return null;
+                    }
+                    return SkiaSharp.SKColorFilter.CreateColorMatrix(colorMatrixColorFilter.Matrix);
                 }
-                return SkiaSharp.SKColorFilter.CreateColorMatrix(colorMatrixColorFilter.Matrix);
-            }
             case LumaColorColorFilter _:
-            {
-                return SkiaSharp.SKColorFilter.CreateLumaColor();
-            }
-            case TableColorFilter tableColorFilter:
-            {
-                if (tableColorFilter.TableA is null
-                    || tableColorFilter.TableR is null
-                    || tableColorFilter.TableG is null
-                    || tableColorFilter.TableB is null)
-                    return null;
                 {
-                    return SkiaSharp.SKColorFilter.CreateTable(
-                        tableColorFilter.TableA,
-                        tableColorFilter.TableR,
-                        tableColorFilter.TableG,
-                        tableColorFilter.TableB);
+                    return SkiaSharp.SKColorFilter.CreateLumaColor();
                 }
-            }
+            case TableColorFilter tableColorFilter:
+                {
+                    if (tableColorFilter.TableA is null
+                        || tableColorFilter.TableR is null
+                        || tableColorFilter.TableG is null
+                        || tableColorFilter.TableB is null)
+                        return null;
+                    {
+                        return SkiaSharp.SKColorFilter.CreateTable(
+                            tableColorFilter.TableA,
+                            tableColorFilter.TableR,
+                            tableColorFilter.TableG,
+                            tableColorFilter.TableB);
+                    }
+                }
             default:
-            {
-                return null;
-            }
+                {
+                    return null;
+                }
         }
     }
 
@@ -458,7 +459,7 @@ public class SkiaModel
             return null;
         }
 
-        var skShader = skPaint.Shader is null 
+        var skShader = skPaint.Shader is null
             ? SkiaSharp.SKShader.CreateColor(ToSKColor(skPaint.Color!.Value), SkiaSharp.SKColorSpace.CreateSrgb())
             : ToSKShader(skPaint.Shader);
 
@@ -479,363 +480,363 @@ public class SkiaModel
         switch (imageFilter)
         {
             case ArithmeticImageFilter arithmeticImageFilter:
-            {
-                if (arithmeticImageFilter.Background is null)
                 {
-                    return null;
-                }
+                    if (arithmeticImageFilter.Background is null)
+                    {
+                        return null;
+                    }
 
-                return arithmeticImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateArithmetic(
-                        arithmeticImageFilter.K1,
-                        arithmeticImageFilter.K2,
-                        arithmeticImageFilter.K3,
-                        arithmeticImageFilter.K4,
-                        arithmeticImageFilter.EforcePMColor,
-                        ToSKImageFilter(arithmeticImageFilter.Background),
-                        ToSKImageFilter(arithmeticImageFilter.Foreground),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateArithmetic(
-                        arithmeticImageFilter.K1,
-                        arithmeticImageFilter.K2,
-                        arithmeticImageFilter.K3,
-                        arithmeticImageFilter.K4,
-                        arithmeticImageFilter.EforcePMColor,
-                        ToSKImageFilter(arithmeticImageFilter.Background),
-                        ToSKImageFilter(arithmeticImageFilter.Foreground));
-            }
+                    return arithmeticImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateArithmetic(
+                            arithmeticImageFilter.K1,
+                            arithmeticImageFilter.K2,
+                            arithmeticImageFilter.K3,
+                            arithmeticImageFilter.K4,
+                            arithmeticImageFilter.EforcePMColor,
+                            ToSKImageFilter(arithmeticImageFilter.Background),
+                            ToSKImageFilter(arithmeticImageFilter.Foreground),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateArithmetic(
+                            arithmeticImageFilter.K1,
+                            arithmeticImageFilter.K2,
+                            arithmeticImageFilter.K3,
+                            arithmeticImageFilter.K4,
+                            arithmeticImageFilter.EforcePMColor,
+                            ToSKImageFilter(arithmeticImageFilter.Background),
+                            ToSKImageFilter(arithmeticImageFilter.Foreground));
+                }
             case BlendModeImageFilter blendModeImageFilter:
-            {
-                if (blendModeImageFilter.Background is null)
                 {
-                    return null;
-                }
+                    if (blendModeImageFilter.Background is null)
+                    {
+                        return null;
+                    }
 
-                return blendModeImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateBlendMode(
-                        ToSKBlendMode(blendModeImageFilter.Mode),
-                        ToSKImageFilter(blendModeImageFilter.Background),
-                        ToSKImageFilter(blendModeImageFilter.Foreground),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateBlendMode(
-                        ToSKBlendMode(blendModeImageFilter.Mode),
-                        ToSKImageFilter(blendModeImageFilter.Background),
-                        ToSKImageFilter(blendModeImageFilter.Foreground));
-            }
+                    return blendModeImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateBlendMode(
+                            ToSKBlendMode(blendModeImageFilter.Mode),
+                            ToSKImageFilter(blendModeImageFilter.Background),
+                            ToSKImageFilter(blendModeImageFilter.Foreground),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateBlendMode(
+                            ToSKBlendMode(blendModeImageFilter.Mode),
+                            ToSKImageFilter(blendModeImageFilter.Background),
+                            ToSKImageFilter(blendModeImageFilter.Foreground));
+                }
             case BlurImageFilter blurImageFilter:
-            {
-                return blurImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateBlur(
-                        blurImageFilter.SigmaX,
-                        blurImageFilter.SigmaY,
-                        ToSKImageFilter(blurImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateBlur(
-                        blurImageFilter.SigmaX,
-                        blurImageFilter.SigmaY,
-                        ToSKImageFilter(blurImageFilter.Input));
-            }
+                {
+                    return blurImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateBlur(
+                            blurImageFilter.SigmaX,
+                            blurImageFilter.SigmaY,
+                            ToSKImageFilter(blurImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateBlur(
+                            blurImageFilter.SigmaX,
+                            blurImageFilter.SigmaY,
+                            ToSKImageFilter(blurImageFilter.Input));
+                }
             case ColorFilterImageFilter colorFilterImageFilter:
-            {
-                if (colorFilterImageFilter.ColorFilter is null)
                 {
-                    return null;
-                }
+                    if (colorFilterImageFilter.ColorFilter is null)
+                    {
+                        return null;
+                    }
 
-                return colorFilterImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateColorFilter(
-                        ToSKColorFilter(colorFilterImageFilter.ColorFilter),
-                        ToSKImageFilter(colorFilterImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateColorFilter(
-                        ToSKColorFilter(colorFilterImageFilter.ColorFilter),
-                        ToSKImageFilter(colorFilterImageFilter.Input));
-            }
+                    return colorFilterImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateColorFilter(
+                            ToSKColorFilter(colorFilterImageFilter.ColorFilter),
+                            ToSKImageFilter(colorFilterImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateColorFilter(
+                            ToSKColorFilter(colorFilterImageFilter.ColorFilter),
+                            ToSKImageFilter(colorFilterImageFilter.Input));
+                }
             case DilateImageFilter dilateImageFilter:
-            {
-                return dilateImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateDilate(
-                        dilateImageFilter.RadiusX,
-                        dilateImageFilter.RadiusY,
-                        ToSKImageFilter(dilateImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateDilate(
-                        dilateImageFilter.RadiusX,
-                        dilateImageFilter.RadiusY,
-                        ToSKImageFilter(dilateImageFilter.Input));
-            }
+                {
+                    return dilateImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateDilate(
+                            dilateImageFilter.RadiusX,
+                            dilateImageFilter.RadiusY,
+                            ToSKImageFilter(dilateImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateDilate(
+                            dilateImageFilter.RadiusX,
+                            dilateImageFilter.RadiusY,
+                            ToSKImageFilter(dilateImageFilter.Input));
+                }
             case DisplacementMapEffectImageFilter displacementMapEffectImageFilter:
-            {
-                if (displacementMapEffectImageFilter.Displacement is null)
                 {
-                    return null;
-                }
+                    if (displacementMapEffectImageFilter.Displacement is null)
+                    {
+                        return null;
+                    }
 
-                return displacementMapEffectImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateDisplacementMapEffect(
-                        ToSKColorChannel(displacementMapEffectImageFilter.XChannelSelector),
-                        ToSKColorChannel(displacementMapEffectImageFilter.YChannelSelector),
-                        displacementMapEffectImageFilter.Scale,
-                        ToSKImageFilter(displacementMapEffectImageFilter.Displacement),
-                        ToSKImageFilter(displacementMapEffectImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateDisplacementMapEffect(
-                        ToSKColorChannel(displacementMapEffectImageFilter.XChannelSelector),
-                        ToSKColorChannel(displacementMapEffectImageFilter.YChannelSelector),
-                        displacementMapEffectImageFilter.Scale,
-                        ToSKImageFilter(displacementMapEffectImageFilter.Displacement),
-                        ToSKImageFilter(displacementMapEffectImageFilter.Input));
-            }
+                    return displacementMapEffectImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateDisplacementMapEffect(
+                            ToSKColorChannel(displacementMapEffectImageFilter.XChannelSelector),
+                            ToSKColorChannel(displacementMapEffectImageFilter.YChannelSelector),
+                            displacementMapEffectImageFilter.Scale,
+                            ToSKImageFilter(displacementMapEffectImageFilter.Displacement),
+                            ToSKImageFilter(displacementMapEffectImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateDisplacementMapEffect(
+                            ToSKColorChannel(displacementMapEffectImageFilter.XChannelSelector),
+                            ToSKColorChannel(displacementMapEffectImageFilter.YChannelSelector),
+                            displacementMapEffectImageFilter.Scale,
+                            ToSKImageFilter(displacementMapEffectImageFilter.Displacement),
+                            ToSKImageFilter(displacementMapEffectImageFilter.Input));
+                }
             case DistantLitDiffuseImageFilter distantLitDiffuseImageFilter:
-            {
-                return distantLitDiffuseImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateDistantLitDiffuse(
-                        ToSKPoint3(distantLitDiffuseImageFilter.Direction),
-                        ToSKColor(distantLitDiffuseImageFilter.LightColor),
-                        distantLitDiffuseImageFilter.SurfaceScale,
-                        distantLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(distantLitDiffuseImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateDistantLitDiffuse(
-                        ToSKPoint3(distantLitDiffuseImageFilter.Direction),
-                        ToSKColor(distantLitDiffuseImageFilter.LightColor),
-                        distantLitDiffuseImageFilter.SurfaceScale,
-                        distantLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(distantLitDiffuseImageFilter.Input));
-            }
+                {
+                    return distantLitDiffuseImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateDistantLitDiffuse(
+                            ToSKPoint3(distantLitDiffuseImageFilter.Direction),
+                            ToSKColor(distantLitDiffuseImageFilter.LightColor),
+                            distantLitDiffuseImageFilter.SurfaceScale,
+                            distantLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(distantLitDiffuseImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateDistantLitDiffuse(
+                            ToSKPoint3(distantLitDiffuseImageFilter.Direction),
+                            ToSKColor(distantLitDiffuseImageFilter.LightColor),
+                            distantLitDiffuseImageFilter.SurfaceScale,
+                            distantLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(distantLitDiffuseImageFilter.Input));
+                }
             case DistantLitSpecularImageFilter distantLitSpecularImageFilter:
-            {
-                return distantLitSpecularImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateDistantLitSpecular(
-                        ToSKPoint3(distantLitSpecularImageFilter.Direction),
-                        ToSKColor(distantLitSpecularImageFilter.LightColor),
-                        distantLitSpecularImageFilter.SurfaceScale,
-                        distantLitSpecularImageFilter.Ks,
-                        distantLitSpecularImageFilter.Shininess,
-                        ToSKImageFilter(distantLitSpecularImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateDistantLitSpecular(
-                        ToSKPoint3(distantLitSpecularImageFilter.Direction),
-                        ToSKColor(distantLitSpecularImageFilter.LightColor),
-                        distantLitSpecularImageFilter.SurfaceScale,
-                        distantLitSpecularImageFilter.Ks,
-                        distantLitSpecularImageFilter.Shininess,
-                        ToSKImageFilter(distantLitSpecularImageFilter.Input));
-            }
+                {
+                    return distantLitSpecularImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateDistantLitSpecular(
+                            ToSKPoint3(distantLitSpecularImageFilter.Direction),
+                            ToSKColor(distantLitSpecularImageFilter.LightColor),
+                            distantLitSpecularImageFilter.SurfaceScale,
+                            distantLitSpecularImageFilter.Ks,
+                            distantLitSpecularImageFilter.Shininess,
+                            ToSKImageFilter(distantLitSpecularImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateDistantLitSpecular(
+                            ToSKPoint3(distantLitSpecularImageFilter.Direction),
+                            ToSKColor(distantLitSpecularImageFilter.LightColor),
+                            distantLitSpecularImageFilter.SurfaceScale,
+                            distantLitSpecularImageFilter.Ks,
+                            distantLitSpecularImageFilter.Shininess,
+                            ToSKImageFilter(distantLitSpecularImageFilter.Input));
+                }
             case ErodeImageFilter erodeImageFilter:
-            {
-                return erodeImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateErode(
-                        erodeImageFilter.RadiusX,
-                        erodeImageFilter.RadiusY,
-                        ToSKImageFilter(erodeImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateErode(
-                        erodeImageFilter.RadiusX,
-                        erodeImageFilter.RadiusY,
-                        ToSKImageFilter(erodeImageFilter.Input));
-            }
+                {
+                    return erodeImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateErode(
+                            erodeImageFilter.RadiusX,
+                            erodeImageFilter.RadiusY,
+                            ToSKImageFilter(erodeImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateErode(
+                            erodeImageFilter.RadiusX,
+                            erodeImageFilter.RadiusY,
+                            ToSKImageFilter(erodeImageFilter.Input));
+                }
             case ImageImageFilter imageImageFilter:
-            {
-                if (imageImageFilter.Image is null)
                 {
-                    return null;
-                }
+                    if (imageImageFilter.Image is null)
+                    {
+                        return null;
+                    }
 
-                return SkiaSharp.SKImageFilter.CreateImage(
-                    ToSKImage(imageImageFilter.Image),
-                    ToSKRect(imageImageFilter.Src),
-                    ToSKRect(imageImageFilter.Dst),
-                    new SkiaSharp.SKSamplingOptions(SkiaSharp.SKCubicResampler.Mitchell));
-            }
+                    return SkiaSharp.SKImageFilter.CreateImage(
+                        ToSKImage(imageImageFilter.Image),
+                        ToSKRect(imageImageFilter.Src),
+                        ToSKRect(imageImageFilter.Dst),
+                        new SkiaSharp.SKSamplingOptions(SkiaSharp.SKCubicResampler.Mitchell));
+                }
             case MatrixConvolutionImageFilter matrixConvolutionImageFilter:
-            {
-                if (matrixConvolutionImageFilter.Kernel is null)
                 {
-                    return null;
-                }
+                    if (matrixConvolutionImageFilter.Kernel is null)
+                    {
+                        return null;
+                    }
 
-                return matrixConvolutionImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateMatrixConvolution(
-                        ToSKSizeI(matrixConvolutionImageFilter.KernelSize),
-                        matrixConvolutionImageFilter.Kernel,
-                        matrixConvolutionImageFilter.Gain,
-                        matrixConvolutionImageFilter.Bias,
-                        ToSKPointI(matrixConvolutionImageFilter.KernelOffset),
-                        ToSKShaderTileMode(matrixConvolutionImageFilter.TileMode),
-                        matrixConvolutionImageFilter.ConvolveAlpha,
-                        ToSKImageFilter(matrixConvolutionImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateMatrixConvolution(
-                        ToSKSizeI(matrixConvolutionImageFilter.KernelSize),
-                        matrixConvolutionImageFilter.Kernel,
-                        matrixConvolutionImageFilter.Gain,
-                        matrixConvolutionImageFilter.Bias,
-                        ToSKPointI(matrixConvolutionImageFilter.KernelOffset),
-                        ToSKShaderTileMode(matrixConvolutionImageFilter.TileMode),
-                        matrixConvolutionImageFilter.ConvolveAlpha,
-                        ToSKImageFilter(matrixConvolutionImageFilter.Input));
-            }
+                    return matrixConvolutionImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateMatrixConvolution(
+                            ToSKSizeI(matrixConvolutionImageFilter.KernelSize),
+                            matrixConvolutionImageFilter.Kernel,
+                            matrixConvolutionImageFilter.Gain,
+                            matrixConvolutionImageFilter.Bias,
+                            ToSKPointI(matrixConvolutionImageFilter.KernelOffset),
+                            ToSKShaderTileMode(matrixConvolutionImageFilter.TileMode),
+                            matrixConvolutionImageFilter.ConvolveAlpha,
+                            ToSKImageFilter(matrixConvolutionImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateMatrixConvolution(
+                            ToSKSizeI(matrixConvolutionImageFilter.KernelSize),
+                            matrixConvolutionImageFilter.Kernel,
+                            matrixConvolutionImageFilter.Gain,
+                            matrixConvolutionImageFilter.Bias,
+                            ToSKPointI(matrixConvolutionImageFilter.KernelOffset),
+                            ToSKShaderTileMode(matrixConvolutionImageFilter.TileMode),
+                            matrixConvolutionImageFilter.ConvolveAlpha,
+                            ToSKImageFilter(matrixConvolutionImageFilter.Input));
+                }
             case MergeImageFilter mergeImageFilter:
-            {
-                if (mergeImageFilter.Filters is null)
                 {
-                    return null;
-                }
+                    if (mergeImageFilter.Filters is null)
+                    {
+                        return null;
+                    }
 
-                return mergeImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateMerge(
-                        ToSKImageFilters(mergeImageFilter.Filters),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateMerge(
-                        ToSKImageFilters(mergeImageFilter.Filters));
-            }
+                    return mergeImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateMerge(
+                            ToSKImageFilters(mergeImageFilter.Filters),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateMerge(
+                            ToSKImageFilters(mergeImageFilter.Filters));
+                }
             case OffsetImageFilter offsetImageFilter:
-            {
-                return offsetImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateOffset(
-                        offsetImageFilter.Dx,
-                        offsetImageFilter.Dy,
-                        ToSKImageFilter(offsetImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateOffset(
-                        offsetImageFilter.Dx,
-                        offsetImageFilter.Dy,
-                        ToSKImageFilter(offsetImageFilter.Input));
-            }
+                {
+                    return offsetImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateOffset(
+                            offsetImageFilter.Dx,
+                            offsetImageFilter.Dy,
+                            ToSKImageFilter(offsetImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateOffset(
+                            offsetImageFilter.Dx,
+                            offsetImageFilter.Dy,
+                            ToSKImageFilter(offsetImageFilter.Input));
+                }
             case PaintImageFilter paintImageFilter:
-            {
-                if (paintImageFilter.Paint is null)
                 {
-                    return null;
-                }
+                    if (paintImageFilter.Paint is null)
+                    {
+                        return null;
+                    }
 
-                return paintImageFilter.Clip is { } clip
-                    ? CreatePaint(paintImageFilter.Paint, clip)
-                    : CreatePaint(paintImageFilter.Paint);
-            }
+                    return paintImageFilter.Clip is { } clip
+                        ? CreatePaint(paintImageFilter.Paint, clip)
+                        : CreatePaint(paintImageFilter.Paint);
+                }
             case ShaderImageFilter shaderImageFilter:
-            {
-                if (shaderImageFilter.Shader is null)
                 {
-                    return null;
-                }
+                    if (shaderImageFilter.Shader is null)
+                    {
+                        return null;
+                    }
 
-                return shaderImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateShader(
-                        ToSKShader(shaderImageFilter.Shader),
-                        shaderImageFilter.Dither,
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateShader(
-                        ToSKShader(shaderImageFilter.Shader),
-                        shaderImageFilter.Dither);
-            }
+                    return shaderImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateShader(
+                            ToSKShader(shaderImageFilter.Shader),
+                            shaderImageFilter.Dither,
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateShader(
+                            ToSKShader(shaderImageFilter.Shader),
+                            shaderImageFilter.Dither);
+                }
             case PictureImageFilter pictureImageFilter:
-            {
-                if (pictureImageFilter.Picture is null)
+                {
+                    if (pictureImageFilter.Picture is null)
+                    {
+                        return null;
+                    }
+
+                    return SkiaSharp.SKImageFilter.CreatePicture(
+                        ToSKPicture(pictureImageFilter.Picture),
+                        ToSKRect(pictureImageFilter.Picture.CullRect));
+                }
+            case PointLitDiffuseImageFilter pointLitDiffuseImageFilter:
+                {
+                    return pointLitDiffuseImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreatePointLitDiffuse(
+                            ToSKPoint3(pointLitDiffuseImageFilter.Location),
+                            ToSKColor(pointLitDiffuseImageFilter.LightColor),
+                            pointLitDiffuseImageFilter.SurfaceScale,
+                            pointLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(pointLitDiffuseImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreatePointLitDiffuse(
+                            ToSKPoint3(pointLitDiffuseImageFilter.Location),
+                            ToSKColor(pointLitDiffuseImageFilter.LightColor),
+                            pointLitDiffuseImageFilter.SurfaceScale,
+                            pointLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(pointLitDiffuseImageFilter.Input));
+                }
+            case PointLitSpecularImageFilter pointLitSpecularImageFilter:
+                {
+                    return pointLitSpecularImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreatePointLitSpecular(
+                            ToSKPoint3(pointLitSpecularImageFilter.Location),
+                            ToSKColor(pointLitSpecularImageFilter.LightColor),
+                            pointLitSpecularImageFilter.SurfaceScale,
+                            pointLitSpecularImageFilter.Ks,
+                            pointLitSpecularImageFilter.Shininess,
+                            ToSKImageFilter(pointLitSpecularImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreatePointLitSpecular(
+                            ToSKPoint3(pointLitSpecularImageFilter.Location),
+                            ToSKColor(pointLitSpecularImageFilter.LightColor),
+                            pointLitSpecularImageFilter.SurfaceScale,
+                            pointLitSpecularImageFilter.Ks,
+                            pointLitSpecularImageFilter.Shininess,
+                            ToSKImageFilter(pointLitSpecularImageFilter.Input));
+                }
+            case SpotLitDiffuseImageFilter spotLitDiffuseImageFilter:
+                {
+                    return spotLitDiffuseImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateSpotLitDiffuse(
+                            ToSKPoint3(spotLitDiffuseImageFilter.Location),
+                            ToSKPoint3(spotLitDiffuseImageFilter.Target),
+                            spotLitDiffuseImageFilter.SpecularExponent,
+                            spotLitDiffuseImageFilter.CutoffAngle,
+                            ToSKColor(spotLitDiffuseImageFilter.LightColor),
+                            spotLitDiffuseImageFilter.SurfaceScale,
+                            spotLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(spotLitDiffuseImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateSpotLitDiffuse(
+                            ToSKPoint3(spotLitDiffuseImageFilter.Location),
+                            ToSKPoint3(spotLitDiffuseImageFilter.Target),
+                            spotLitDiffuseImageFilter.SpecularExponent,
+                            spotLitDiffuseImageFilter.CutoffAngle,
+                            ToSKColor(spotLitDiffuseImageFilter.LightColor),
+                            spotLitDiffuseImageFilter.SurfaceScale,
+                            spotLitDiffuseImageFilter.Kd,
+                            ToSKImageFilter(spotLitDiffuseImageFilter.Input));
+                }
+            case SpotLitSpecularImageFilter spotLitSpecularImageFilter:
+                {
+                    return spotLitSpecularImageFilter.Clip is { } clip
+                        ? SkiaSharp.SKImageFilter.CreateSpotLitSpecular(
+                            ToSKPoint3(spotLitSpecularImageFilter.Location),
+                            ToSKPoint3(spotLitSpecularImageFilter.Target),
+                            spotLitSpecularImageFilter.SpecularExponent,
+                            spotLitSpecularImageFilter.CutoffAngle,
+                            ToSKColor(spotLitSpecularImageFilter.LightColor),
+                            spotLitSpecularImageFilter.SurfaceScale,
+                            spotLitSpecularImageFilter.Ks,
+                            spotLitSpecularImageFilter.SpecularExponent,
+                            ToSKImageFilter(spotLitSpecularImageFilter.Input),
+                            ToSKRect(clip))
+                        : SkiaSharp.SKImageFilter.CreateSpotLitSpecular(
+                            ToSKPoint3(spotLitSpecularImageFilter.Location),
+                            ToSKPoint3(spotLitSpecularImageFilter.Target),
+                            spotLitSpecularImageFilter.SpecularExponent,
+                            spotLitSpecularImageFilter.CutoffAngle,
+                            ToSKColor(spotLitSpecularImageFilter.LightColor),
+                            spotLitSpecularImageFilter.SurfaceScale,
+                            spotLitSpecularImageFilter.Ks,
+                            spotLitSpecularImageFilter.SpecularExponent,
+                            ToSKImageFilter(spotLitSpecularImageFilter.Input));
+                }
+            case TileImageFilter tileImageFilter:
+                {
+                    return SkiaSharp.SKImageFilter.CreateTile(
+                        ToSKRect(tileImageFilter.Src),
+                        ToSKRect(tileImageFilter.Dst),
+                        ToSKImageFilter(tileImageFilter.Input));
+                }
+            default:
                 {
                     return null;
                 }
-
-                return SkiaSharp.SKImageFilter.CreatePicture(
-                    ToSKPicture(pictureImageFilter.Picture),
-                    ToSKRect(pictureImageFilter.Picture.CullRect));
-            }
-            case PointLitDiffuseImageFilter pointLitDiffuseImageFilter:
-            {
-                return pointLitDiffuseImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreatePointLitDiffuse(
-                        ToSKPoint3(pointLitDiffuseImageFilter.Location),
-                        ToSKColor(pointLitDiffuseImageFilter.LightColor),
-                        pointLitDiffuseImageFilter.SurfaceScale,
-                        pointLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(pointLitDiffuseImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreatePointLitDiffuse(
-                        ToSKPoint3(pointLitDiffuseImageFilter.Location),
-                        ToSKColor(pointLitDiffuseImageFilter.LightColor),
-                        pointLitDiffuseImageFilter.SurfaceScale,
-                        pointLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(pointLitDiffuseImageFilter.Input));
-            }
-            case PointLitSpecularImageFilter pointLitSpecularImageFilter:
-            {
-                return pointLitSpecularImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreatePointLitSpecular(
-                        ToSKPoint3(pointLitSpecularImageFilter.Location),
-                        ToSKColor(pointLitSpecularImageFilter.LightColor),
-                        pointLitSpecularImageFilter.SurfaceScale,
-                        pointLitSpecularImageFilter.Ks,
-                        pointLitSpecularImageFilter.Shininess,
-                        ToSKImageFilter(pointLitSpecularImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreatePointLitSpecular(
-                        ToSKPoint3(pointLitSpecularImageFilter.Location),
-                        ToSKColor(pointLitSpecularImageFilter.LightColor),
-                        pointLitSpecularImageFilter.SurfaceScale,
-                        pointLitSpecularImageFilter.Ks,
-                        pointLitSpecularImageFilter.Shininess,
-                        ToSKImageFilter(pointLitSpecularImageFilter.Input));
-            }
-            case SpotLitDiffuseImageFilter spotLitDiffuseImageFilter:
-            {
-                return spotLitDiffuseImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateSpotLitDiffuse(
-                        ToSKPoint3(spotLitDiffuseImageFilter.Location),
-                        ToSKPoint3(spotLitDiffuseImageFilter.Target),
-                        spotLitDiffuseImageFilter.SpecularExponent,
-                        spotLitDiffuseImageFilter.CutoffAngle,
-                        ToSKColor(spotLitDiffuseImageFilter.LightColor),
-                        spotLitDiffuseImageFilter.SurfaceScale,
-                        spotLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(spotLitDiffuseImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateSpotLitDiffuse(
-                        ToSKPoint3(spotLitDiffuseImageFilter.Location),
-                        ToSKPoint3(spotLitDiffuseImageFilter.Target),
-                        spotLitDiffuseImageFilter.SpecularExponent,
-                        spotLitDiffuseImageFilter.CutoffAngle,
-                        ToSKColor(spotLitDiffuseImageFilter.LightColor),
-                        spotLitDiffuseImageFilter.SurfaceScale,
-                        spotLitDiffuseImageFilter.Kd,
-                        ToSKImageFilter(spotLitDiffuseImageFilter.Input));
-            }
-            case SpotLitSpecularImageFilter spotLitSpecularImageFilter:
-            {
-                return spotLitSpecularImageFilter.Clip is { } clip
-                    ? SkiaSharp.SKImageFilter.CreateSpotLitSpecular(
-                        ToSKPoint3(spotLitSpecularImageFilter.Location),
-                        ToSKPoint3(spotLitSpecularImageFilter.Target),
-                        spotLitSpecularImageFilter.SpecularExponent,
-                        spotLitSpecularImageFilter.CutoffAngle,
-                        ToSKColor(spotLitSpecularImageFilter.LightColor),
-                        spotLitSpecularImageFilter.SurfaceScale,
-                        spotLitSpecularImageFilter.Ks,
-                        spotLitSpecularImageFilter.SpecularExponent,
-                        ToSKImageFilter(spotLitSpecularImageFilter.Input),
-                        ToSKRect(clip))
-                    : SkiaSharp.SKImageFilter.CreateSpotLitSpecular(
-                        ToSKPoint3(spotLitSpecularImageFilter.Location),
-                        ToSKPoint3(spotLitSpecularImageFilter.Target),
-                        spotLitSpecularImageFilter.SpecularExponent,
-                        spotLitSpecularImageFilter.CutoffAngle,
-                        ToSKColor(spotLitSpecularImageFilter.LightColor),
-                        spotLitSpecularImageFilter.SurfaceScale,
-                        spotLitSpecularImageFilter.Ks,
-                        spotLitSpecularImageFilter.SpecularExponent,
-                        ToSKImageFilter(spotLitSpecularImageFilter.Input));
-            }
-            case TileImageFilter tileImageFilter:
-            {
-                return SkiaSharp.SKImageFilter.CreateTile(
-                    ToSKRect(tileImageFilter.Src),
-                    ToSKRect(tileImageFilter.Dst),
-                    ToSKImageFilter(tileImageFilter.Input));
-            }
-            default:
-            {
-                return null;
-            }
         }
     }
 
@@ -866,15 +867,15 @@ public class SkiaModel
         switch (pathEffect)
         {
             case DashPathEffect dashPathEffect:
-            {
-                return SkiaSharp.SKPathEffect.CreateDash(
-                    dashPathEffect.Intervals,
-                    dashPathEffect.Phase);
-            }
+                {
+                    return SkiaSharp.SKPathEffect.CreateDash(
+                        dashPathEffect.Intervals,
+                        dashPathEffect.Phase);
+                }
             default:
-            {
-                return null;
-            }
+                {
+                    return null;
+                }
         }
     }
 
@@ -940,8 +941,8 @@ public class SkiaModel
         var textAlign = ToSKTextAlign(paint.TextAlign);
         var typeface = ToSKTypeface(paint.Typeface);
         var textEncoding = ToSKTextEncoding(paint.TextEncoding);
-        var color = paint.Color is null 
-            ? SkiaSharp.SKColor.Empty : 
+        var color = paint.Color is null
+            ? SkiaSharp.SKColor.Empty :
             ToSKColor(paint.Color.Value);
         var shader = ToSKShader(paint.Shader);
         var colorFilter = ToSKColorFilter(paint.ColorFilter);
@@ -1028,94 +1029,94 @@ public class SkiaModel
         switch (pathCommand)
         {
             case MoveToPathCommand moveToPathCommand:
-            {
-                var x = moveToPathCommand.X;
-                var y = moveToPathCommand.Y;
-                skPath.MoveTo(x, y);
-                break;
-            }
-            case LineToPathCommand lineToPathCommand:
-            {
-                var x = lineToPathCommand.X;
-                var y = lineToPathCommand.Y;
-                skPath.LineTo(x, y);
-                break;
-            }
-            case ArcToPathCommand arcToPathCommand:
-            {
-                var rx = arcToPathCommand.Rx;
-                var ry = arcToPathCommand.Ry;
-                var xAxisRotate = arcToPathCommand.XAxisRotate;
-                var largeArc = ToSKPathArcSize(arcToPathCommand.LargeArc);
-                var sweep = ToSKPathDirection(arcToPathCommand.Sweep);
-                var x = arcToPathCommand.X;
-                var y = arcToPathCommand.Y;
-                skPath.ArcTo(rx, ry, xAxisRotate, largeArc, sweep, x, y);
-                break;
-            }
-            case QuadToPathCommand quadToPathCommand:
-            {
-                var x0 = quadToPathCommand.X0;
-                var y0 = quadToPathCommand.Y0;
-                var x1 = quadToPathCommand.X1;
-                var y1 = quadToPathCommand.Y1;
-                skPath.QuadTo(x0, y0, x1, y1);
-                break;
-            }
-            case CubicToPathCommand cubicToPathCommand:
-            {
-                var x0 = cubicToPathCommand.X0;
-                var y0 = cubicToPathCommand.Y0;
-                var x1 = cubicToPathCommand.X1;
-                var y1 = cubicToPathCommand.Y1;
-                var x2 = cubicToPathCommand.X2;
-                var y2 = cubicToPathCommand.Y2;
-                skPath.CubicTo(x0, y0, x1, y1, x2, y2);
-                break;
-            }
-            case ClosePathCommand _:
-            {
-                skPath.Close();
-                break;
-            }
-            case AddRectPathCommand addRectPathCommand:
-            {
-                var rect = ToSKRect(addRectPathCommand.Rect);
-                skPath.AddRect(rect);
-                break;
-            }
-            case AddRoundRectPathCommand addRoundRectPathCommand:
-            {
-                var rect = ToSKRect(addRoundRectPathCommand.Rect);
-                var rx = addRoundRectPathCommand.Rx;
-                var ry = addRoundRectPathCommand.Ry;
-                skPath.AddRoundRect(rect, rx, ry);
-                break;
-            }
-            case AddOvalPathCommand addOvalPathCommand:
-            {
-                var rect = ToSKRect(addOvalPathCommand.Rect);
-                skPath.AddOval(rect);
-                break;
-            }
-            case AddCirclePathCommand addCirclePathCommand:
-            {
-                var x = addCirclePathCommand.X;
-                var y = addCirclePathCommand.Y;
-                var radius = addCirclePathCommand.Radius;
-                skPath.AddCircle(x, y, radius);
-                break;
-            }
-            case AddPolyPathCommand addPolyPathCommand:
-            {
-                if (addPolyPathCommand.Points is { })
                 {
-                    var points = ToSKPoints(addPolyPathCommand.Points);
-                    var close = addPolyPathCommand.Close;
-                    skPath.AddPoly(points, close);
+                    var x = moveToPathCommand.X;
+                    var y = moveToPathCommand.Y;
+                    skPath.MoveTo(x, y);
+                    break;
                 }
-                break;
-            }
+            case LineToPathCommand lineToPathCommand:
+                {
+                    var x = lineToPathCommand.X;
+                    var y = lineToPathCommand.Y;
+                    skPath.LineTo(x, y);
+                    break;
+                }
+            case ArcToPathCommand arcToPathCommand:
+                {
+                    var rx = arcToPathCommand.Rx;
+                    var ry = arcToPathCommand.Ry;
+                    var xAxisRotate = arcToPathCommand.XAxisRotate;
+                    var largeArc = ToSKPathArcSize(arcToPathCommand.LargeArc);
+                    var sweep = ToSKPathDirection(arcToPathCommand.Sweep);
+                    var x = arcToPathCommand.X;
+                    var y = arcToPathCommand.Y;
+                    skPath.ArcTo(rx, ry, xAxisRotate, largeArc, sweep, x, y);
+                    break;
+                }
+            case QuadToPathCommand quadToPathCommand:
+                {
+                    var x0 = quadToPathCommand.X0;
+                    var y0 = quadToPathCommand.Y0;
+                    var x1 = quadToPathCommand.X1;
+                    var y1 = quadToPathCommand.Y1;
+                    skPath.QuadTo(x0, y0, x1, y1);
+                    break;
+                }
+            case CubicToPathCommand cubicToPathCommand:
+                {
+                    var x0 = cubicToPathCommand.X0;
+                    var y0 = cubicToPathCommand.Y0;
+                    var x1 = cubicToPathCommand.X1;
+                    var y1 = cubicToPathCommand.Y1;
+                    var x2 = cubicToPathCommand.X2;
+                    var y2 = cubicToPathCommand.Y2;
+                    skPath.CubicTo(x0, y0, x1, y1, x2, y2);
+                    break;
+                }
+            case ClosePathCommand _:
+                {
+                    skPath.Close();
+                    break;
+                }
+            case AddRectPathCommand addRectPathCommand:
+                {
+                    var rect = ToSKRect(addRectPathCommand.Rect);
+                    skPath.AddRect(rect);
+                    break;
+                }
+            case AddRoundRectPathCommand addRoundRectPathCommand:
+                {
+                    var rect = ToSKRect(addRoundRectPathCommand.Rect);
+                    var rx = addRoundRectPathCommand.Rx;
+                    var ry = addRoundRectPathCommand.Ry;
+                    skPath.AddRoundRect(rect, rx, ry);
+                    break;
+                }
+            case AddOvalPathCommand addOvalPathCommand:
+                {
+                    var rect = ToSKRect(addOvalPathCommand.Rect);
+                    skPath.AddOval(rect);
+                    break;
+                }
+            case AddCirclePathCommand addCirclePathCommand:
+                {
+                    var x = addCirclePathCommand.X;
+                    var y = addCirclePathCommand.Y;
+                    var radius = addCirclePathCommand.Radius;
+                    skPath.AddCircle(x, y, radius);
+                    break;
+                }
+            case AddPolyPathCommand addPolyPathCommand:
+                {
+                    if (addPolyPathCommand.Points is { })
+                    {
+                        var points = ToSKPoints(addPolyPathCommand.Points);
+                        var close = addPolyPathCommand.Close;
+                        skPath.AddPoly(points, close);
+                    }
+                    break;
+                }
         }
     }
 
@@ -1193,7 +1194,8 @@ public class SkiaModel
 
             var skPath = ToSKPath(clip.Path);
             var skPathClip = ToSKPath(clip.Clip);
-            if (skPathClip is { }) skPath = skPath.Op(skPathClip, SkiaSharp.SKPathOp.Intersect);
+            if (skPathClip is { })
+                skPath = skPath.Op(skPathClip, SkiaSharp.SKPathOp.Intersect);
 
             if (clip.Transform is { })
             {
@@ -1217,7 +1219,8 @@ public class SkiaModel
             if (clipPath.Clip?.Clips is { })
             {
                 var skPathClip = ToSKPath(clipPath.Clip);
-                if (skPathClip is { }) skPathResult = skPathResult.Op(skPathClip, SkiaSharp.SKPathOp.Intersect);
+                if (skPathClip is { })
+                    skPathResult = skPathResult.Op(skPathClip, SkiaSharp.SKPathOp.Intersect);
             }
 
             if (clipPath.Transform is { })
@@ -1267,132 +1270,143 @@ public class SkiaModel
         switch (canvasCommand)
         {
             case ClipPathCanvasCommand clipPathCanvasCommand:
-            {
-                if (clipPathCanvasCommand.ClipPath is { })
                 {
-                    var path = ToSKPath(clipPathCanvasCommand.ClipPath);
-                    var operation = ToSKClipOperation(clipPathCanvasCommand.Operation);
-                    var antialias = clipPathCanvasCommand.Antialias;
-                    skCanvas.ClipPath(path, operation, antialias);
-                }
-                break;
-            }
-            case ClipRectCanvasCommand clipRectCanvasCommand:
-            {
-                var rect = ToSKRect(clipRectCanvasCommand.Rect);
-                var operation = ToSKClipOperation(clipRectCanvasCommand.Operation);
-                var antialias = clipRectCanvasCommand.Antialias;
-                skCanvas.ClipRect(rect, operation, antialias);
-                break;
-            }
-            case SaveCanvasCommand _:
-            {
-                skCanvas.Save();
-                break;
-            }
-            case RestoreCanvasCommand _:
-            {
-                skCanvas.Restore();
-                break;
-            }
-            case SetMatrixCanvasCommand setMatrixCanvasCommand:
-            {
-                var matrix = ToSKMatrix(setMatrixCanvasCommand.TotalMatrix);
-                skCanvas.SetMatrix(matrix);
-                break;
-            }
-            case SaveLayerCanvasCommand saveLayerCanvasCommand:
-            {
-                if (saveLayerCanvasCommand.Paint is { })
-                {
-                    var paint = wireframe
-                        ? ToWireframePaint(saveLayerCanvasCommand.Paint)
-                        : ToSKPaint(saveLayerCanvasCommand.Paint);
-                    skCanvas.SaveLayer(paint);
-                }
-                else
-                {
-                    skCanvas.SaveLayer();
-                }
-                break;
-            }
-            case DrawImageCanvasCommand drawImageCanvasCommand:
-            {
-                if (drawImageCanvasCommand.Image is { })
-                {
-                    if (wireframe)
+                    if (clipPathCanvasCommand.ClipPath is { })
                     {
-                        var rectPath = new SkiaSharp.SKPath();
-                        rectPath.AddRect(ToSKRect(drawImageCanvasCommand.Dest));
-                        skCanvas.DrawPath(rectPath, ToWireframePaint(null));
+                        var path = ToSKPath(clipPathCanvasCommand.ClipPath);
+                        var operation = ToSKClipOperation(clipPathCanvasCommand.Operation);
+                        var antialias = clipPathCanvasCommand.Antialias;
+                        skCanvas.ClipPath(path, operation, antialias);
+                    }
+                    break;
+                }
+            case ClipRectCanvasCommand clipRectCanvasCommand:
+                {
+                    var rect = ToSKRect(clipRectCanvasCommand.Rect);
+                    var operation = ToSKClipOperation(clipRectCanvasCommand.Operation);
+                    var antialias = clipRectCanvasCommand.Antialias;
+                    skCanvas.ClipRect(rect, operation, antialias);
+                    break;
+                }
+            case SaveCanvasCommand _:
+                {
+                    skCanvas.Save();
+                    break;
+                }
+            case RestoreCanvasCommand _:
+                {
+                    skCanvas.Restore();
+                    break;
+                }
+            case SetMatrixCanvasCommand setMatrixCanvasCommand:
+                {
+                    var matrix = ToSKMatrix(setMatrixCanvasCommand.TotalMatrix);
+                    skCanvas.SetMatrix(matrix);
+                    break;
+                }
+            case SaveLayerCanvasCommand saveLayerCanvasCommand:
+                {
+                    if (saveLayerCanvasCommand.Paint is { })
+                    {
+                        var paint = wireframe
+                            ? ToWireframePaint(saveLayerCanvasCommand.Paint)
+                            : ToSKPaint(saveLayerCanvasCommand.Paint);
+                        skCanvas.SaveLayer(paint);
                     }
                     else
                     {
-                        var image = ToSKImage(drawImageCanvasCommand.Image);
-                        var source = ToSKRect(drawImageCanvasCommand.Source);
-                        var dest = ToSKRect(drawImageCanvasCommand.Dest);
-                        var paint = ToSKPaint(drawImageCanvasCommand.Paint);
-                        skCanvas.DrawImage(image, source, dest, paint);
+                        skCanvas.SaveLayer();
                     }
+                    break;
                 }
-                break;
-            }
+            case DrawImageCanvasCommand drawImageCanvasCommand:
+                {
+                    if (drawImageCanvasCommand.Image is { })
+                    {
+                        if (wireframe)
+                        {
+                            var rectPath = new SkiaSharp.SKPath();
+                            rectPath.AddRect(ToSKRect(drawImageCanvasCommand.Dest));
+                            skCanvas.DrawPath(rectPath, ToWireframePaint(null));
+                        }
+                        else
+                        {
+                            var image = ToSKImage(drawImageCanvasCommand.Image);
+                            var source = ToSKRect(drawImageCanvasCommand.Source);
+                            var dest = ToSKRect(drawImageCanvasCommand.Dest);
+                            var paint = ToSKPaint(drawImageCanvasCommand.Paint);
+                            skCanvas.DrawImage(image, source, dest, paint);
+                        }
+                    }
+                    break;
+                }
             case DrawPathCanvasCommand drawPathCanvasCommand:
-            {
-                if (drawPathCanvasCommand.Path is { } && drawPathCanvasCommand.Paint is { })
                 {
-                    var path = ToSKPath(drawPathCanvasCommand.Path);
-                    var paint = wireframe
-                        ? ToWireframePaint(drawPathCanvasCommand.Paint)
-                        : ToSKPaint(drawPathCanvasCommand.Paint);
-                    skCanvas.DrawPath(path, paint);
+                    if (drawPathCanvasCommand.Path is { } && drawPathCanvasCommand.Paint is { })
+                    {
+                        var path = ToSKPath(drawPathCanvasCommand.Path);
+                        var paint = wireframe
+                            ? ToWireframePaint(drawPathCanvasCommand.Paint)
+                            : ToSKPaint(drawPathCanvasCommand.Paint);
+                        skCanvas.DrawPath(path, paint);
+                    }
+                    break;
                 }
-                break;
-            }
+            case DrawLineCanvasCommand drawLineCanvasCommand:
+                {
+                    if (drawLineCanvasCommand.Paint is { })
+                    {
+                        var paint = wireframe
+                            ? ToWireframePaint(drawLineCanvasCommand.Paint)
+                            : ToSKPaint(drawLineCanvasCommand.Paint);
+                        skCanvas.DrawLine(drawLineCanvasCommand.X0, drawLineCanvasCommand.Y0, drawLineCanvasCommand.X1, drawLineCanvasCommand.Y1, paint);
+                    }
+                    break;
+                }
             case DrawTextBlobCanvasCommand drawPositionedTextCanvasCommand:
-            {
-                if (drawPositionedTextCanvasCommand.TextBlob?.Points is { } && drawPositionedTextCanvasCommand.Paint is { })
                 {
-                    var text = drawPositionedTextCanvasCommand.TextBlob.Text;
-                    var points = ToSKPoints(drawPositionedTextCanvasCommand.TextBlob.Points);
-                    var paint = wireframe
-                        ? ToWireframePaint(drawPositionedTextCanvasCommand.Paint)
-                        : ToSKPaint(drawPositionedTextCanvasCommand.Paint);
-                    var font = paint?.ToFont();
-                    var textBlob = SkiaSharp.SKTextBlob.CreatePositioned(text, font, points);
-                    skCanvas.DrawText(textBlob, 0, 0, paint);
+                    if (drawPositionedTextCanvasCommand.TextBlob?.Points is { } && drawPositionedTextCanvasCommand.Paint is { })
+                    {
+                        var text = drawPositionedTextCanvasCommand.TextBlob.Text;
+                        var points = ToSKPoints(drawPositionedTextCanvasCommand.TextBlob.Points);
+                        var paint = wireframe
+                            ? ToWireframePaint(drawPositionedTextCanvasCommand.Paint)
+                            : ToSKPaint(drawPositionedTextCanvasCommand.Paint);
+                        var font = paint?.ToFont();
+                        var textBlob = SkiaSharp.SKTextBlob.CreatePositioned(text, font, points);
+                        skCanvas.DrawText(textBlob, 0, 0, paint);
+                    }
+                    break;
                 }
-                break;
-            }
             case DrawTextCanvasCommand drawTextCanvasCommand:
-            {
-                if (drawTextCanvasCommand.Paint is { })
                 {
-                    var text = drawTextCanvasCommand.Text;
-                    var x = drawTextCanvasCommand.X;
-                    var y = drawTextCanvasCommand.Y;
-                    var paint = wireframe
-                        ? ToWireframePaint(drawTextCanvasCommand.Paint)
-                        : ToSKPaint(drawTextCanvasCommand.Paint);
-                    skCanvas.DrawText(text, x, y, paint);
+                    if (drawTextCanvasCommand.Paint is { })
+                    {
+                        var text = drawTextCanvasCommand.Text;
+                        var x = drawTextCanvasCommand.X;
+                        var y = drawTextCanvasCommand.Y;
+                        var paint = wireframe
+                            ? ToWireframePaint(drawTextCanvasCommand.Paint)
+                            : ToSKPaint(drawTextCanvasCommand.Paint);
+                        skCanvas.DrawText(text, x, y, paint);
+                    }
+                    break;
                 }
-                break;
-            }
             case DrawTextOnPathCanvasCommand drawTextOnPathCanvasCommand:
-            {
-                if (drawTextOnPathCanvasCommand.Path is { } && drawTextOnPathCanvasCommand.Paint is { })
                 {
-                    var text = drawTextOnPathCanvasCommand.Text;
-                    var path = ToSKPath(drawTextOnPathCanvasCommand.Path);
-                    var hOffset = drawTextOnPathCanvasCommand.HOffset;
-                    var vOffset = drawTextOnPathCanvasCommand.VOffset;
-                    var paint = wireframe
-                        ? ToWireframePaint(drawTextOnPathCanvasCommand.Paint)
-                        : ToSKPaint(drawTextOnPathCanvasCommand.Paint);
-                    skCanvas.DrawTextOnPath(text, path, hOffset, vOffset, paint);
+                    if (drawTextOnPathCanvasCommand.Path is { } && drawTextOnPathCanvasCommand.Paint is { })
+                    {
+                        var text = drawTextOnPathCanvasCommand.Text;
+                        var path = ToSKPath(drawTextOnPathCanvasCommand.Path);
+                        var hOffset = drawTextOnPathCanvasCommand.HOffset;
+                        var vOffset = drawTextOnPathCanvasCommand.VOffset;
+                        var paint = wireframe
+                            ? ToWireframePaint(drawTextOnPathCanvasCommand.Paint)
+                            : ToSKPaint(drawTextOnPathCanvasCommand.Paint);
+                        skCanvas.DrawTextOnPath(text, path, hOffset, vOffset, paint);
+                    }
+                    break;
                 }
-                break;
-            }
         }
     }
 

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -25,7 +25,7 @@ public class SkiaSvgAssetLoader : Model.ISvgAssetLoader
     {
         var data = ShimSkiaSharp.SKImage.FromStream(stream);
         using var image = SkiaSharp.SKImage.FromEncodedData(data);
-        return new ShimSkiaSharp.SKImage {Data = data, Width = image.Width, Height = image.Height};
+        return new ShimSkiaSharp.SKImage { Data = data, Width = image.Width, Height = image.Height };
     }
 
     /// <inheritdoc />
@@ -132,7 +132,11 @@ public class SkiaSvgAssetLoader : Model.ISvgAssetLoader
             Ascent = skMetrics.Ascent,
             Descent = skMetrics.Descent,
             Bottom = skMetrics.Bottom,
-            Leading = skMetrics.Leading
+            Leading = skMetrics.Leading,
+            UnderlinePosition = skMetrics.UnderlinePosition ?? 0f,
+            UnderlineThickness = skMetrics.UnderlineThickness ?? 0f,
+            StrikeoutPosition = skMetrics.StrikeoutPosition ?? 0f,
+            StrikeoutThickness = skMetrics.StrikeoutThickness ?? 0f
         };
     }
 

--- a/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
+++ b/src/Svg.SourceGenerator.Skia/SkiaGeneratorSvgAssetLoader.cs
@@ -10,7 +10,7 @@ public class SkiaGeneratorSvgAssetLoader : Model.ISvgAssetLoader
     {
         var data = ShimSkiaSharp.SKImage.FromStream(stream);
         using var image = SkiaSharp.SKImage.FromEncodedData(data);
-        return new ShimSkiaSharp.SKImage {Data = data, Width = image.Width, Height = image.Height};
+        return new ShimSkiaSharp.SKImage { Data = data, Width = image.Width, Height = image.Height };
     }
 
     public List<Model.TypefaceSpan> FindTypefaces(string? text, ShimSkiaSharp.SKPaint paintPreferredTypeface)
@@ -39,7 +39,11 @@ public class SkiaGeneratorSvgAssetLoader : Model.ISvgAssetLoader
             Descent = size * 0.2f,
             Top = -size * 0.8f,
             Bottom = size * 0.2f,
-            Leading = 0f
+            Leading = 0f,
+            UnderlinePosition = 0f,
+            UnderlineThickness = 0f,
+            StrikeoutPosition = 0f,
+            StrikeoutThickness = 0f
         };
     }
 

--- a/tests/Svg.Skia.UnitTests/resvgTests.cs
+++ b/tests/Svg.Skia.UnitTests/resvgTests.cs
@@ -8,10 +8,10 @@ namespace Svg.Skia.UnitTests;
 
 public class resvgTests : SvgUnitTest
 {
-    private static string GetSvgPath(string name) 
+    private static string GetSvgPath(string name)
         => Path.Combine("..", "..", "..", "..", "..", "externals", "resvg", "tests", "svg", name);
 
-    private static string GetExpectedPngPath(string name) 
+    private static string GetExpectedPngPath(string name)
         => Path.Combine("..", "..", "..", "..", "..", "externals", "resvg", "tests", "png", name);
 
     private static string GetActualPngPath(string name)
@@ -41,7 +41,7 @@ public class resvgTests : SvgUnitTest
     [Theory(Skip = "TODO")]
     [InlineData("a-alignment-baseline-001", 0.022)]
     public void a_alignment_baseline(string name, double errorThreshold) => TestImpl(name, errorThreshold);
- 
+
     [Theory(Skip = "TODO")]
     [InlineData("a-baseline-shift-001", 0.022)]
     [InlineData("a-baseline-shift-002", 0.022)]
@@ -263,7 +263,7 @@ public class resvgTests : SvgUnitTest
     [Theory]
     [InlineData("a-font-001", 0.022)]
     public void a_font(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-family-001", 0.022)]
     [InlineData("a-font-family-002", 0.022)]
@@ -300,28 +300,28 @@ public class resvgTests : SvgUnitTest
     [InlineData("a-font-size-019", 0.022, Skip = "TODO")]
     [InlineData("a-font-size-020", 0.022, Skip = "TODO")]
     public void a_font_size(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-size-adjust-001", 0.022)]
     public void a_font_size_adjust(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-stretch-001", 0.022)]
     [InlineData("a-font-stretch-002", 0.022)]
     [InlineData("a-font-stretch-003", 0.022)]
     public void a_font_stretch(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-style-001", 0.022)]
     [InlineData("a-font-style-002", 0.022)]
     [InlineData("a-font-style-003", 0.022)]
     public void a_font_style(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-variant-001", 0.022)]
     [InlineData("a-font-variant-002", 0.022)]
     public void a_font_variant(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-font-weight-001", 0.022)]
     [InlineData("a-font-weight-002", 0.022)]
@@ -336,11 +336,11 @@ public class resvgTests : SvgUnitTest
     [InlineData("a-font-weight-011", 0.022)]
     [InlineData("a-font-weight-012", 0.022)]
     public void a_font_weight(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-glyph-orientation-horizontal-001", 0.022)]
     public void a_glyph_orientation_horizontal(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-        
+
     [Theory(Skip = "TODO")]
     [InlineData("a-glyph-orientation-vertical-001", 0.022)]
     public void a_glyph_orientation_vertical(string name, double errorThreshold) => TestImpl(name, errorThreshold);
@@ -355,11 +355,11 @@ public class resvgTests : SvgUnitTest
     [InlineData("a-isolation-001", 0.022)]
     [InlineData("a-isolation-002", 0.022)]
     public void a_isolation(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-kerning-001", 0.022)]
     public void a_kerning(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-    
+
     [Theory(Skip = "TODO")]
     [InlineData("a-lengthAdjust-001", 0.022)]
     public void a_lengthAdjust(string name, double errorThreshold) => TestImpl(name, errorThreshold);
@@ -581,8 +581,7 @@ public class resvgTests : SvgUnitTest
     [InlineData("a-text-anchor-012", 0.022)]
     [InlineData("a-text-anchor-013", 0.022)]
     public void a_text_anchor(string name, double errorThreshold) => TestImpl(name, errorThreshold);
-
-    [Theory(Skip = "TODO")]
+    [Theory]
     [InlineData("a-text-decoration-001", 0.022)]
     [InlineData("a-text-decoration-002", 0.022)]
     [InlineData("a-text-decoration-003", 0.022)]


### PR DESCRIPTION
## Summary
- extend `SKFontMetrics` to expose text decoration metrics
- add `DrawLine` command to SKCanvas and render lines in SkiaModel
- implement underline, overline and line-through in `TextDrawable`
- handle metrics in asset loaders
- enable `a-text-decoration-*` test group

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release -p:EnableSourceLink=false` *(fails: 19, passed: 908, skipped: 494)*

------
https://chatgpt.com/codex/tasks/task_e_687caabfee048321bc649ec03c42590c