### PR TITLE
Enable editing color data for gradient meshes

### DIFF
--- a/samples/AvalonDraw/GradientMeshEditorWindow.axaml
+++ b/samples/AvalonDraw/GradientMeshEditorWindow.axaml
@@ -3,15 +3,30 @@
         x:Class="AvalonDraw.GradientMeshEditorWindow"
         Width="400" Height="300"
         Title="Edit Gradient Mesh">
-    <Canvas x:Name="MeshCanvas" Background="Gray">
-        <ItemsControl ItemsSource="{Binding Points}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Ellipse Width="10" Height="10" Fill="Red"
-                             Canvas.Left="{Binding Position.X}"
-                             Canvas.Top="{Binding Position.Y}" />
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-    </Canvas>
+    <DockPanel Margin="10" LastChildFill="True">
+        <Canvas x:Name="MeshCanvas" Background="Gray" DockPanel.Dock="Top" Height="200">
+            <ItemsControl ItemsSource="{Binding Points}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Canvas.Left="{Binding Position.X}"
+                                    Canvas.Top="{Binding Position.Y}">
+                            <Ellipse Width="10" Height="10"
+                                     Fill="{Binding Color, Converter={StaticResource ColorStringConverter}}"/>
+                            <ColorPicker Width="120"
+                                         Color="{Binding Color, Mode=TwoWay, Converter={StaticResource ColorStringConverter}}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Canvas>
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
+            <Button Content="OK" Width="80" Click="OkButton_OnClick"/>
+            <Button Content="Cancel" Width="80" Click="CancelButton_OnClick"/>
+        </StackPanel>
+    </DockPanel>
 </Window>

--- a/samples/AvalonDraw/GradientMeshEditorWindow.axaml.cs
+++ b/samples/AvalonDraw/GradientMeshEditorWindow.axaml.cs
@@ -18,13 +18,14 @@ public partial class GradientMeshEditorWindow : Window
     public GradientMeshEditorWindow(GradientMesh mesh)
     {
         InitializeComponent();
+        Resources["ColorStringConverter"] = new ColorStringConverter();
         _canvas = this.FindControl<Canvas>("MeshCanvas");
         foreach (var p in mesh.Points)
-            Points.Add(p);
+            Points.Add(new GradientMeshPoint(p.Position, p.Color));
         _canvas.PointerPressed += OnPointerPressed;
         _canvas.PointerReleased += OnPointerReleased;
         _canvas.PointerMoved += OnPointerMoved;
-        _canvas.DataContext = this;
+        DataContext = this;
     }
 
     private void InitializeComponent()
@@ -57,21 +58,21 @@ public partial class GradientMeshEditorWindow : Window
             return;
 
         var pos = e.GetPosition(_canvas);
-        var index = Points.IndexOf(_dragging);
-        if (index >= 0)
-        {
-            Points[index] = _dragging with { Position = new ShimSkiaSharp.SKPoint((float)pos.X, (float)pos.Y) };
-            _dragging = Points[index];
-        }
+        _dragging.Position = new ShimSkiaSharp.SKPoint((float)pos.X, (float)pos.Y);
     }
 
-    public GradientMesh Result
+    public GradientMesh Result { get; private set; } = new();
+
+    private void OkButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        get
-        {
-            var mesh = new GradientMesh();
-            mesh.Points.AddRange(Points);
-            return mesh;
-        }
+        Result.Points.Clear();
+        foreach (var p in Points)
+            Result.Points.Add(new GradientMeshPoint(p.Position, p.Color));
+        Close(true);
+    }
+
+    private void CancelButton_OnClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close(false);
     }
 }

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -287,7 +287,15 @@ public partial class MainWindow : Window
                 btn.Click += async (_, _) =>
                 {
                     var dlg = new GradientMeshEditorWindow(meshEntry.Mesh);
-                    await dlg.ShowDialog(this);
+                    var result = await dlg.ShowDialog<bool>(this);
+                    if (result)
+                    {
+                        meshEntry.Mesh.Points.Clear();
+                        foreach (var p in dlg.Result.Points)
+                            meshEntry.Mesh.Points.Add(p);
+                        meshEntry.Value = string.Empty;
+                        meshEntry.NotifyChanged();
+                    }
                 };
                 return btn;
             }

--- a/samples/AvalonDraw/Services/GradientMeshEntry.cs
+++ b/samples/AvalonDraw/Services/GradientMeshEntry.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using ShimSkiaSharp;
+using Svg;
 using Svg.Model;
 
 namespace AvalonDraw.Services;
@@ -11,10 +16,39 @@ public class GradientMeshEntry : PropertyEntry
         : base("Mesh", string.Empty, (_, __) => { })
     {
         Mesh = mesh;
+        Value = Serialize(mesh);
     }
 
     public override void Apply(object target)
     {
-        // Placeholder for applying the mesh to an object.
+        if (target is SvgGradientServer grad)
+        {
+            grad.CustomAttributes["gradient-mesh"] = Serialize(Mesh);
+        }
+    }
+
+    private static string Serialize(GradientMesh mesh)
+    {
+        var parts = new List<string>(mesh.Points.Count);
+        parts.AddRange(mesh.Points.Select(p =>
+            FormattableString.Invariant($"{p.Position.X},{p.Position.Y},{p.Color}")));
+        return string.Join(';', parts);
+    }
+
+    public static GradientMesh Parse(string text)
+    {
+        var mesh = new GradientMesh();
+        foreach (var part in text.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var items = part.Split(',');
+            if (items.Length != 3)
+                continue;
+            if (float.TryParse(items[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                float.TryParse(items[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+            {
+                mesh.Points.Add(new GradientMeshPoint(new SKPoint(x, y), items[2]));
+            }
+        }
+        return mesh;
     }
 }

--- a/samples/AvalonDraw/Services/PropertiesService.cs
+++ b/samples/AvalonDraw/Services/PropertiesService.cs
@@ -90,6 +90,13 @@ public class PropertiesService
             var gEntry = new GradientStopsEntry(grad);
             gEntry.PropertyChanged += OnEntryChanged;
             Properties.Add(gEntry);
+
+            if (grad.CustomAttributes.TryGetValue("gradient-mesh", out var mesh))
+            {
+                var mEntry = new GradientMeshEntry(GradientMeshEntry.Parse(mesh));
+                mEntry.PropertyChanged += OnEntryChanged;
+                Properties.Add(mEntry);
+            }
         }
 
         if (element is SvgVisualElement vis &&

--- a/src/Svg.Model/GradientMesh.cs
+++ b/src/Svg.Model/GradientMesh.cs
@@ -19,4 +19,39 @@ public sealed class GradientMesh
 /// <summary>
 /// Defines a single mesh point with position and color.
 /// </summary>
-public sealed record GradientMeshPoint(SKPoint Position, SKColor Color);
+public sealed class GradientMeshPoint
+{
+    public SKPoint Position { get; set; }
+    public string Color { get; set; } = "#000000";
+
+    public GradientMeshPoint() { }
+
+    public GradientMeshPoint(SKPoint position, string color)
+    {
+        Position = position;
+        Color = color;
+    }
+
+    public SKColor ToSKColor()
+    {
+        var hex = Color.TrimStart('#');
+        byte a = 255;
+        byte r = 0;
+        byte g = 0;
+        byte b = 0;
+        if (hex.Length == 8)
+        {
+            a = System.Convert.ToByte(hex.Substring(0, 2), 16);
+            r = System.Convert.ToByte(hex.Substring(2, 2), 16);
+            g = System.Convert.ToByte(hex.Substring(4, 2), 16);
+            b = System.Convert.ToByte(hex.Substring(6, 2), 16);
+        }
+        else if (hex.Length == 6)
+        {
+            r = System.Convert.ToByte(hex.Substring(0, 2), 16);
+            g = System.Convert.ToByte(hex.Substring(2, 2), 16);
+            b = System.Convert.ToByte(hex.Substring(4, 2), 16);
+        }
+        return new SKColor(r, g, b, a);
+    }
+}

--- a/src/Svg.Model/Services/GradientMeshService.cs
+++ b/src/Svg.Model/Services/GradientMeshService.cs
@@ -27,7 +27,7 @@ public static class GradientMeshService
         return SKShader.CreateLinearGradient(
             first.Position,
             last.Position,
-            new[] { (SKColorF)first.Color, (SKColorF)last.Color },
+            new[] { (SKColorF)first.ToSKColor(), (SKColorF)last.ToSKColor() },
             SKColorSpace.Srgb,
             new[] { 0f, 1f },
             SKShaderTileMode.Clamp);


### PR DESCRIPTION
## Summary
- add mutable `GradientMeshPoint` with color string support
- allow gradient mesh service to convert color strings
- provide mesh editing UI with color pickers
- serialize mesh color data and apply changes

## Testing
- `dotnet format --no-restore`
- `dotnet build Svg.Skia.sln -c Release`
- `dotnet test Svg.Skia.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687caab066d0832193014cec19355f14