### PR TITLE
Allow multi-selection with modifiers

### DIFF
--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -617,8 +617,7 @@ public partial class MainWindow : Window
     private async void SvgView_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         var point = e.GetPosition(SvgView);
-        var mods = e.KeyModifiers;
-        if (IsMultiSelectionMode(mods) && e.GetCurrentPoint(SvgView).Properties.IsLeftButtonPressed)
+        if (IsMultiSelectionMode(e.KeyModifiers) && e.GetCurrentPoint(SvgView).Properties.IsLeftButtonPressed)
         {
             if (_pathService.IsEditing)
                 _pathService.Stop();

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -1156,10 +1156,24 @@ public partial class MainWindow : Window
                 var p1 = _boxStartPicture;
                 var p2 = _boxEndPicture;
                 var rect = new Shim.SKRect(Math.Min(p1.X, p2.X), Math.Min(p1.Y, p2.Y), Math.Max(p1.X, p2.X), Math.Max(p1.Y, p2.Y));
+                var skRect = new SK.SKRect(rect.Left, rect.Top, rect.Right, rect.Bottom);
                 var elements = svg.HitTestElements(rect).OfType<SvgVisualElement>();
                 if (!_includeHidden)
                     elements = elements.Where(IsElementVisible);
-                var hits = elements.ToList();
+                var root = svg.Drawable as DrawableBase;
+                var hits = new List<SvgVisualElement>();
+                var leftToRight = p2.X >= p1.X;
+                foreach (var el in elements)
+                {
+                    if (root is null)
+                        continue;
+                    var dr = FindDrawable(root, el);
+                    if (dr is null)
+                        continue;
+                    var b = SelectionService.GetBoundsRect(GetBoundsInfo(dr));
+                    if (!leftToRight || SelectionService.ContainsRect(skRect, b))
+                        hits.Add(el);
+                }
                 var mods = e.KeyModifiers;
                 if ((mods & KeyModifiers.Shift) != 0)
                 {

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -617,16 +617,18 @@ public partial class MainWindow : Window
     private async void SvgView_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         var point = e.GetPosition(SvgView);
-        if (IsMultiSelectionMode(e.KeyModifiers) && e.GetCurrentPoint(SvgView).Properties.IsLeftButtonPressed)
+        var hasStart = SvgView.TryGetPicturePoint(point, out var picturePt);
+        if (IsMultiSelectionMode(e.KeyModifiers) && e.GetCurrentPoint(SvgView).Properties.IsLeftButtonPressed &&
+            !(_multiSelected.Count > 0 && !_multiBounds.IsEmpty && hasStart && _multiBounds.Contains(picturePt.X, picturePt.Y)))
         {
             if (_pathService.IsEditing)
                 _pathService.Stop();
             _boxSelecting = true;
             _boxStart = point;
             _boxEnd = point;
-            if (SvgView.TryGetPicturePoint(point, out var sp))
+            if (hasStart)
             {
-                _boxStartPicture = new SK.SKPoint((float)sp.X, (float)sp.Y);
+                _boxStartPicture = new SK.SKPoint((float)picturePt.X, (float)picturePt.Y);
                 _boxEndPicture = _boxStartPicture;
             }
             e.Pointer.Capture(SvgView);

--- a/samples/AvalonDraw/MainWindow.axaml.cs
+++ b/samples/AvalonDraw/MainWindow.axaml.cs
@@ -902,6 +902,12 @@ public partial class MainWindow : Window
                 _selectedDrawable = skSvg.HitTestDrawables(pp).FirstOrDefault();
                 _selectedElement = null;
                 _selectedSvgElement = null;
+                if (_multiSelected.Count > 0)
+                {
+                    _multiSelected.Clear();
+                    _multiDrawables.Clear();
+                    _multiBounds = SK.SKRect.Empty;
+                }
                 if (_pathService.IsEditing)
                     _pathService.Stop();
                 if (_polyEditing)
@@ -1242,6 +1248,12 @@ public partial class MainWindow : Window
                 }
                 else
                 {
+                    if (_multiSelected.Count > 0)
+                    {
+                        _multiSelected.Clear();
+                        _multiDrawables.Clear();
+                        _multiBounds = SK.SKRect.Empty;
+                    }
                     _selectedElement = element;
                     _selectedDrawable = skSvg.HitTestDrawables(_pressPoint).FirstOrDefault(d => d.Element == _selectedElement);
                     _selectedSvgElement = _selectedElement;
@@ -1258,6 +1270,12 @@ public partial class MainWindow : Window
                 _selectedDrawable = null;
                 _selectedElement = null;
                 _selectedSvgElement = null;
+                if (_multiSelected.Count > 0)
+                {
+                    _multiSelected.Clear();
+                    _multiDrawables.Clear();
+                    _multiBounds = SK.SKRect.Empty;
+                }
                 UpdateSelectedDrawable();
                 SvgView.InvalidateVisual();
             }
@@ -2689,6 +2707,12 @@ public partial class MainWindow : Window
                 _selectedDrawable = null;
                 _selectedElement = null;
                 _selectedSvgElement = null;
+                if (_multiSelected.Count > 0)
+                {
+                    _multiSelected.Clear();
+                    _multiDrawables.Clear();
+                    _multiBounds = SK.SKRect.Empty;
+                }
                 DocumentTree.SelectedItem = null;
                 SvgView.InvalidateVisual();
             }

--- a/samples/AvalonDraw/Services/SelectionService.cs
+++ b/samples/AvalonDraw/Services/SelectionService.cs
@@ -60,6 +60,12 @@ public class SelectionService
         return new SK.SKRect(left, top, right, bottom);
     }
 
+    public static bool ContainsRect(SK.SKRect outer, SK.SKRect inner)
+    {
+        return outer.Left <= inner.Left && outer.Right >= inner.Right &&
+               outer.Top <= inner.Top && outer.Bottom >= inner.Bottom;
+    }
+
     public int HitHandle(BoundsInfo b, SK.SKPoint pt, float scale, out SK.SKPoint center)
     {
         center = b.Center;


### PR DESCRIPTION
## Summary
- enable multi-selection when holding Ctrl or Shift in Select tool

## Testing
- `dotnet build Svg.Skia.sln -c Release -p:ContinuousIntegrationBuild=true -p:EnableSourceLink=false`
- `dotnet test Svg.Skia.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687f7b0b02048321a8f3d87ec6bda616