### PR TITLE
Dependencies issue fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,10 +15,10 @@
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.12.35" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.8" />
     <PackageVersion Include="ReactiveGenerator" Version="0.12.0" />
     <PackageVersion Include="Svg" Version="3.4.4" />
-    <PackageVersion Include="ExCSS" Version="4.3.0" />
+    <PackageVersion Include="ExCSS" Version="4.3.1" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
@@ -28,11 +28,11 @@
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
@@ -40,11 +40,14 @@
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageVersion Include="Nuke.Common" Version="9.0.4" />
-    <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.4" />
+    <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,8 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,10 +18,11 @@
     <PackageVersion Include="ReactiveGenerator" Version="0.12.0" />
     <PackageVersion Include="Svg" Version="3.4.4" />
     <PackageVersion Include="ExCSS" Version="4.3.0" />
-    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />

--- a/Svg.Skia.sln
+++ b/Svg.Skia.sln
@@ -58,6 +58,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{5BFEF4F8
 		build\System.CommandLine.props = build\System.CommandLine.props
 		build\XUnit.props = build\XUnit.props
 		build\SkiaSharp.Native.props = build\SkiaSharp.Native.props
+		build\Base.props = build\Base.props
+		build\SkiaSharp.Native.v3.props = build\SkiaSharp.Native.v3.props
+		build\SkiaSharp.v3.props = build\SkiaSharp.v3.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7863AE7D-FF68-45BF-BA68-6FA0E5604CB7}"

--- a/Svg.Skia.sln
+++ b/Svg.Skia.sln
@@ -48,18 +48,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{5BFEF4F8
 		build\Avalonia.Skia.props = build\Avalonia.Skia.props
 		build\Avalonia.Themes.Fluent.props = build\Avalonia.Themes.Fluent.props
 		build\Avalonia.Web.props = build\Avalonia.Web.props
-		build\HarfBuzzSharp.NativeAssets.Linux.props = build\HarfBuzzSharp.NativeAssets.Linux.props
 		build\Newtonsoft.Json.props = build\Newtonsoft.Json.props
 		build\ReferenceAssemblies.props = build\ReferenceAssemblies.props
 		build\SignAssembly.props = build\SignAssembly.props
 		build\SixLabors.ImageSharp.props = build\SixLabors.ImageSharp.props
-		build\SkiaSharp.HarfBuzz.props = build\SkiaSharp.HarfBuzz.props
 		build\SkiaSharp.Linux.props = build\SkiaSharp.Linux.props
 		build\SkiaSharp.props = build\SkiaSharp.props
 		build\SourceLink.props = build\SourceLink.props
 		build\Svg.props = build\Svg.props
 		build\System.CommandLine.props = build\System.CommandLine.props
 		build\XUnit.props = build\XUnit.props
+		build\SkiaSharp.Native.props = build\SkiaSharp.Native.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7863AE7D-FF68-45BF-BA68-6FA0E5604CB7}"

--- a/Svg.Skia.sln
+++ b/Svg.Skia.sln
@@ -52,7 +52,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{5BFEF4F8
 		build\ReferenceAssemblies.props = build\ReferenceAssemblies.props
 		build\SignAssembly.props = build\SignAssembly.props
 		build\SixLabors.ImageSharp.props = build\SixLabors.ImageSharp.props
-		build\SkiaSharp.Linux.props = build\SkiaSharp.Linux.props
 		build\SkiaSharp.props = build\SkiaSharp.props
 		build\SourceLink.props = build\SourceLink.props
 		build\Svg.props = build\Svg.props

--- a/build/HarfBuzzSharp.NativeAssets.Linux.props
+++ b/build/HarfBuzzSharp.NativeAssets.Linux.props
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
-  </ItemGroup>
-</Project>

--- a/build/SkiaSharp.HarfBuzz.props
+++ b/build/SkiaSharp.HarfBuzz.props
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="SkiaSharp.HarfBuzz" />
-  </ItemGroup>
-</Project>

--- a/build/SkiaSharp.Linux.props
+++ b/build/SkiaSharp.Linux.props
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-  </ItemGroup>
-</Project>

--- a/build/SkiaSharp.Native.props
+++ b/build/SkiaSharp.Native.props
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <!-- Core SkiaSharp package -->
-    <PackageReference Include="SkiaSharp" />
-    
-    <!-- Platform-specific native assets - these should match the SkiaSharp version -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" />

--- a/build/SkiaSharp.Native.props
+++ b/build/SkiaSharp.Native.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!-- Core SkiaSharp package -->
+    <PackageReference Include="SkiaSharp" />
+    
+    <!-- Platform-specific native assets - these should match the SkiaSharp version -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+  </ItemGroup>
+</Project>

--- a/build/SkiaSharp.Native.v3.props
+++ b/build/SkiaSharp.Native.v3.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="3.116.1" />
+  </ItemGroup>
+</Project>

--- a/build/SkiaSharp.Native.v3.props
+++ b/build/SkiaSharp.Native.v3.props
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" VersionOverride="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" VersionOverride="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" VersionOverride="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" VersionOverride="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="3.119.0" />
   </ItemGroup>
 </Project>

--- a/build/SkiaSharp.v3.props
+++ b/build/SkiaSharp.v3.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" VersionOverride="3.116.1" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp" VersionOverride="3.119.0" />
   </ItemGroup>
 </Project>

--- a/build/SkiaSharp.v3.props
+++ b/build/SkiaSharp.v3.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" VersionOverride="3.116.1" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" VersionOverride="3.116.1" />
+  </ItemGroup>
+</Project>

--- a/samples/AvalonDraw/AvalonDraw.csproj
+++ b/samples/AvalonDraw/AvalonDraw.csproj
@@ -17,7 +17,7 @@
   <Import Project="..\..\build\Avalonia.Desktop.props" />
   <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Linux.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Controls.DataGrid" />

--- a/samples/AvalonDraw/AvalonDraw.csproj
+++ b/samples/AvalonDraw/AvalonDraw.csproj
@@ -16,8 +16,8 @@
   <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
   <Import Project="..\..\build\Avalonia.Diagnostics.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Controls.DataGrid" />

--- a/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
+++ b/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
@@ -33,7 +33,7 @@
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Linux.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
   <Import Project="..\..\build\System.CommandLine.props" />
   <ItemGroup>

--- a/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
+++ b/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
@@ -32,8 +32,8 @@
 
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
   <Import Project="..\..\build\System.CommandLine.props" />
   <ItemGroup>

--- a/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
+++ b/samples/Svg.Skia.Converter/Svg.Skia.Converter.csproj
@@ -34,7 +34,6 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SkiaSharp.Linux.props" />
-  <Import Project="..\..\build\HarfBuzzSharp.NativeAssets.Linux.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
   <Import Project="..\..\build\System.CommandLine.props" />
   <ItemGroup>

--- a/samples/Svg.SourceGenerator.Skia.Sample/Svg.SourceGenerator.Skia.Sample.csproj
+++ b/samples/Svg.SourceGenerator.Skia.Sample/Svg.SourceGenerator.Skia.Sample.csproj
@@ -17,8 +17,8 @@
     <AdditionalFiles Include="Svg/pservers-pattern-01-b.svg" />
   </ItemGroup>
 
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Svg.Model\Svg.Model.csproj" />

--- a/samples/Svg.SourceGenerator.Skia.Sample/Svg.SourceGenerator.Skia.Sample.csproj
+++ b/samples/Svg.SourceGenerator.Skia.Sample/Svg.SourceGenerator.Skia.Sample.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Linux.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Svg.Model\Svg.Model.csproj" />

--- a/samples/SvgToPng/SvgToPng.csproj
+++ b/samples/SvgToPng/SvgToPng.csproj
@@ -28,7 +28,8 @@
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
 
   <ItemGroup>

--- a/samples/TestApp.Desktop/TestApp.Desktop.csproj
+++ b/samples/TestApp.Desktop/TestApp.Desktop.csproj
@@ -24,7 +24,8 @@
   <Import Project="..\..\build\Avalonia.Desktop.props" />
   <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Avalonia.ReactiveUI.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
 
   <ItemGroup>

--- a/samples/TestApp/TestApp.csproj
+++ b/samples/TestApp/TestApp.csproj
@@ -28,7 +28,8 @@
   <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Avalonia.ReactiveUI.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
 
   <ItemGroup>

--- a/src/Skia.Controls.Avalonia/Skia.Controls.Avalonia.csproj
+++ b/src/Skia.Controls.Avalonia/Skia.Controls.Avalonia.csproj
@@ -21,8 +21,6 @@
   <Import Project="..\..\build\SourceLink.props" />
   <!--<Import Project="..\..\build\SignAssembly.props" />-->
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
 
   <PropertyGroup>

--- a/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
+++ b/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
@@ -21,9 +21,7 @@
   <Import Project="..\..\build\SourceLink.props" />
   <!--<Import Project="..\..\build\SignAssembly.props" />-->
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <!--<Import Project="..\..\build\SkiaSharp.props" />-->
   <Import Project="..\..\build\Avalonia.props" />
-  <!--<Import Project="..\..\build\Avalonia.Skia.props" />-->
 
   <PropertyGroup>
     <VersionPrefix>$(AvaloniaVersionPrefix)</VersionPrefix>

--- a/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
@@ -21,8 +21,6 @@
   <Import Project="..\..\build\SourceLink.props" />
   <!--<Import Project="..\..\build\SignAssembly.props" />-->
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
 
   <PropertyGroup>

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -642,11 +642,12 @@ public class SkiaModel
                     return null;
                 }
 
-                return SkiaSharp.SKImageFilter.CreateImage(
-                    ToSKImage(imageImageFilter.Image),
-                    ToSKRect(imageImageFilter.Src),
-                    ToSKRect(imageImageFilter.Dst),
-                    new SkiaSharp.SKSamplingOptions(SkiaSharp.SKCubicResampler.Mitchell));
+                    return SkiaSharp.SKImageFilter.CreateImage(
+                        ToSKImage(imageImageFilter.Image),
+                        ToSKRect(imageImageFilter.Src),
+                        ToSKRect(imageImageFilter.Dst), 
+                        SkiaSharp.SKFilterQuality.High);
+                    //new SkiaSharp.SKSamplingOptions(SkiaSharp.SKCubicResampler.Mitchell));
             }
             case MatrixConvolutionImageFilter matrixConvolutionImageFilter:
             {

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-using System;
 using System.Collections.Generic;
 using ShimSkiaSharp;
 
@@ -642,11 +641,11 @@ public class SkiaModel
                     return null;
                 }
 
-                    return SkiaSharp.SKImageFilter.CreateImage(
-                        ToSKImage(imageImageFilter.Image),
-                        ToSKRect(imageImageFilter.Src),
-                        ToSKRect(imageImageFilter.Dst), 
-                        SkiaSharp.SKFilterQuality.High);
+                return SkiaSharp.SKImageFilter.CreateImage(
+                    ToSKImage(imageImageFilter.Image),
+                    ToSKRect(imageImageFilter.Src),
+                    ToSKRect(imageImageFilter.Dst), 
+                    SkiaSharp.SKFilterQuality.High);
             }
             case MatrixConvolutionImageFilter matrixConvolutionImageFilter:
             {

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -647,7 +647,6 @@ public class SkiaModel
                         ToSKRect(imageImageFilter.Src),
                         ToSKRect(imageImageFilter.Dst), 
                         SkiaSharp.SKFilterQuality.High);
-                    //new SkiaSharp.SKSamplingOptions(SkiaSharp.SKCubicResampler.Mitchell));
             }
             case MatrixConvolutionImageFilter matrixConvolutionImageFilter:
             {

--- a/src/Svg.Skia/Svg.Skia.csproj
+++ b/src/Svg.Skia/Svg.Skia.csproj
@@ -32,6 +32,7 @@
   <Import Project="..\..\build\SourceLink.props" />
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SkiaSharp.Native.props" />
   <ItemGroup>
     <!--<ProjectReference Include="..\..\externals\SVG\Source\Svg.csproj" />-->

--- a/src/Svg.Skia/Svg.Skia.csproj
+++ b/src/Svg.Skia/Svg.Skia.csproj
@@ -32,7 +32,7 @@
   <Import Project="..\..\build\SourceLink.props" />
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\Avalonia.Skia.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
   <ItemGroup>
     <!--<ProjectReference Include="..\..\externals\SVG\Source\Svg.csproj" />-->
     <ProjectReference Include="..\Svg.Model\Svg.Model.csproj" />

--- a/src/Svg.Skia/Svg.Skia.csproj
+++ b/src/Svg.Skia/Svg.Skia.csproj
@@ -32,10 +32,7 @@
   <Import Project="..\..\build\SourceLink.props" />
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.HarfBuzz.props" />
-
-  <!--<Import Project="..\..\build\Svg.props" />-->
+  <Import Project="..\..\build\Avalonia.Skia.props" />
   <ItemGroup>
     <!--<ProjectReference Include="..\..\externals\SVG\Source\Svg.csproj" />-->
     <ProjectReference Include="..\Svg.Model\Svg.Model.csproj" />

--- a/tests/Avalonia.Svg.Skia.UiTests/Avalonia.Svg.Skia.UiTests.csproj
+++ b/tests/Avalonia.Svg.Skia.UiTests/Avalonia.Svg.Skia.UiTests.csproj
@@ -10,7 +10,8 @@
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\SkiaSharp.Linux.props" />
   <Import Project="..\..\build\HarfBuzzSharp.NativeAssets.Linux.props" />
   <Import Project="..\..\build\Avalonia.props" />

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
@@ -12,7 +12,6 @@
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SkiaSharp.Linux.props" />
-  <Import Project="..\..\build\HarfBuzzSharp.NativeAssets.Linux.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
  

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
@@ -10,8 +10,8 @@
 
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
  

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj
@@ -11,7 +11,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Linux.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
  

--- a/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
+++ b/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
@@ -11,7 +11,7 @@
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SixLabors.ImageSharp.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Linux.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Svg.Skia\Svg.Skia.csproj" />

--- a/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
+++ b/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
@@ -10,8 +10,8 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SixLabors.ImageSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Svg.Skia\Svg.Skia.csproj" />

--- a/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
+++ b/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
@@ -12,7 +12,6 @@
   <Import Project="..\..\build\SixLabors.ImageSharp.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SkiaSharp.Linux.props" />
-  <Import Project="..\..\build\HarfBuzzSharp.NativeAssets.Linux.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Svg.Skia\Svg.Skia.csproj" />


### PR DESCRIPTION
The problem:
https://www.nuget.org/packages/Avalonia.Skia/11.3.3#dependencies-body-tab
SkiaSharp.NativeAssets.Linux (>= 2.88.9)
SkiaSharp.NativeAssets.WebAssembly (>= 2.88.9)

Svg.Controls.Skia.Avalonia has SkiaSharp version 3.116.1 https://www.nuget.org/packages/Svg.Controls.Skia.Avalonia/11.3.0.2#dependencies-body-tab


To avoid these conflicts I suggest using the same SkiaSharp version as used Avalonia package.
As shown in this PR.

OR if you want to force a custom SkiaSharp version in the Svg.Controls.Skia.Avalonia package, you must care about 
dependent assets:
SkiaSharp.NativeAssets.Linux
SkiaSharp.NativeAssets.Win32
SkiaSharp.NativeAssets.WebAssembly