### PR TITLE
Update SkiaSharp.NativeAssets.Linux references to NoDependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Svg" Version="3.4.4" />
     <PackageVersion Include="ExCSS" Version="4.3.1" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9" />

--- a/build/SkiaSharp.Native.props
+++ b/build/SkiaSharp.Native.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />

--- a/build/SkiaSharp.Native.v3.props
+++ b/build/SkiaSharp.Native.v3.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" VersionOverride="3.119.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" VersionOverride="3.119.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" VersionOverride="3.119.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="3.119.0" />


### PR DESCRIPTION
Update SkiaSharp.NativeAssets.Linux references to NoDependencies

Addresses issue #406 
https://github.com/wieslawsoltes/Svg.Skia/issues/406
