### PR TITLE
Prepare text pipeline for future Pretext integration

### DIFF
--- a/plan/pretext-text-engine-feasibility-and-refactor-plan.md
+++ b/plan/pretext-text-engine-feasibility-and-refactor-plan.md
@@ -1,0 +1,601 @@
+# Pretext Text Engine Feasibility And Refactor Plan
+
+Analysis date: 2026-04-14
+
+## Executive Summary
+
+`PretextSharp` is not a drop-in replacement for the current `Svg.Skia` text engine.
+
+It is a good candidate for a **narrow text preparation, line-breaking, and measurement-cache layer** after upstream and local integration work, but it is **not currently feasible** to use it as the core rendering engine for all SVG text in `Svg.Skia`.
+
+The main blockers are:
+
+- `Pretext` currently targets `net10.0` only, while `Svg.Skia` ships `netstandard2.0;net461;net6.0;net8.0;net10.0`.
+- `Pretext` currently depends on `SkiaSharp 3.119.1`, while `Svg.Skia` is on `SkiaSharp 2.88.9`.
+- `Pretext` does not draw text, shape glyphs for final output, build text paths, or model SVG-specific placement rules.
+- `Pretext` measures via a CSS-like font string and a static global font cache; `Svg.Skia` measures through `SKPaint`, HarfBuzz shaping, browser-compatible font fallback, custom typeface providers, and embedded SVG fonts.
+
+Recommendation:
+
+- Do **not** try to replace `Svg.SceneGraph/SvgSceneTextCompiler.cs` wholesale with `Pretext`.
+- Use `Pretext` only as a future **prepared text / line-fit / measurement-cache subsystem** behind a new abstraction.
+- Keep SVG-specific rendering, shaping, text-path placement, per-glyph coordinates, vertical layout, decoration geometry, and SVG font outline rendering in `Svg.Skia`.
+
+## PretextSharp Analysis
+
+Analyzed repository:
+
+- `/Users/wieslawsoltes/GitHub/PretextSharp`
+
+Relevant package/runtime facts:
+
+- `src/Pretext/Pretext.csproj`
+  - target framework: `net10.0`
+  - package id: `Pretext`
+- `Directory.Build.props`
+  - version: `0.1.0-preview.1`
+- `Directory.Packages.props`
+  - `SkiaSharp 3.119.1`
+
+### What Pretext does well
+
+Core type and API surface:
+
+- `PretextLayout.Prepare(...)`
+- `PretextLayout.PrepareWithSegments(...)`
+- `PretextLayout.Layout(...)`
+- `PretextLayout.LayoutWithLines(...)`
+- `PretextLayout.LayoutNextLine(...)`
+- `PretextLayout.LayoutNextLineRange(...)`
+- `PretextLayout.WalkLineRanges(...)`
+- `PretextLayout.MeasureLineStats(...)`
+- `PretextLayout.MeasureNaturalWidth(...)`
+- `PretextLayout.PrepareRichInline(...)`
+- `PretextLayout.MeasureRichInlineStats(...)`
+- `PretextLayout.ClearCache()`
+- `PretextLayout.SetLocale(...)`
+
+Capability summary:
+
+- grapheme-aware preparation and line fitting
+- reusable prepared text objects
+- segment-level cached measurement
+- whitespace normalization
+- soft hyphen handling
+- tab stop handling
+- bidi segment levels
+- locale-aware segmentation where ICU is available
+- streamed line walking for custom layout engines
+
+Architectural strengths:
+
+- clean split between expensive preparation and cheap repeated layout
+- deterministic line-walking API
+- useful prepared-text abstraction for repeated measurement
+- small, understandable core
+
+### What Pretext does not do
+
+From source and docs:
+
+- it does not draw text
+- it does not own baseline policy
+- it does not expose hit testing or caret/selection behavior
+- it does not shape final draw runs through HarfBuzz
+- it does not build text outlines or paths
+- it does not model SVG text placement attributes
+
+Important implementation constraints:
+
+- font input is a CSS-like string, not `SKPaint`
+- `FontSpec.Parse(...)` only understands:
+  - `px`
+  - numeric weight / `bold`
+  - `italic` / `oblique`
+  - primary family after size
+- unsupported font syntax falls back to `16px Arial`
+- generic families are hard-mapped to:
+  - `sans-serif` / `system-ui` -> `Arial`
+  - `serif` -> `Times New Roman`
+  - `monospace` / `ui-monospace` -> `Menlo`
+
+Measurement model limitations for `Svg.Skia` integration:
+
+- measurement is driven by `SKFont` / `SKTypeface.FromFamilyName(...)`
+- there is no public production API for plugging in a custom measurement callback
+- the only override hook is `SetMeasurementOverrideForTests(...)`, which is `internal`
+- caches are static and global:
+  - `FontStates`
+  - `_segmentTextCaches`
+- cache keys are based on the font string, not on `SKSvgSettings`, typeface providers, shaping options, or paint flags
+
+### Practical meaning for Svg.Skia
+
+`Pretext` is a **layout helper** and **measurement cache**, not a renderer. It can help answer:
+
+- how wide is this prepared text?
+- how many lines fit in this width?
+- where are the line boundaries?
+
+It cannot directly answer:
+
+- which fallback typeface span should draw this substring?
+- what HarfBuzz cluster advances should be used?
+- how should `x/y/dx/dy/rotate` lists alter placement?
+- how should `textLength` and `lengthAdjust` modify final glyph origins?
+- how should text follow a path?
+- how should vertical writing mode and glyph rotation work?
+- how should embedded SVG `<font>` outlines render?
+
+## Svg.Skia Text Pipeline Analysis
+
+The current text system is distributed across a few critical files.
+
+### Primary text engine
+
+- `src/Svg.SceneGraph/SvgSceneTextCompiler.cs`
+
+This is the real text engine today. It handles:
+
+- text subtree traversal
+- whitespace normalization and content flattening
+- root and child `x/y/dx/dy`
+- `rotate`
+- `baseline-shift`
+- `letter-spacing`
+- `word-spacing`
+- `textLength`
+- `lengthAdjust`
+- `text-anchor`
+- bidi helpers
+- sequential fast paths
+- per-codepoint placement
+- vertical writing mode
+- `textPath`
+- `tspan`
+- `tref`
+- clip-path text path generation
+- decoration geometry
+- measurement and bounds estimation
+
+This file is not just drawing code. It mixes:
+
+- text extraction
+- shaping selection
+- measurement
+- cache lookups
+- placement rules
+- rendering
+- clip-path path generation
+
+### SVG font rendering
+
+- `src/Svg.SceneGraph/SvgFontTextRenderer.cs`
+
+This file provides repo-owned support for SVG `<font>` glyph outlines. `Pretext` has no equivalent capability.
+
+### Font fallback and text measurement bridge
+
+- `src/Svg.Skia/SkiaSvgAssetLoader.cs`
+
+This file provides:
+
+- `FindTypefaces(...)`
+- `FindRunTypeface(...)`
+- `GetFontMetrics(...)`
+- `MeasureText(...)`
+- `TryShapeGlyphRun(...)`
+- `GetTextPath(...)`
+
+It also owns:
+
+- browser-compatible fallback scanning
+- custom typeface-provider cache usage
+- bridge from SVG text code to native Skia measurement/path APIs
+
+### HarfBuzz shaping and stable measurement
+
+- `src/Svg.Skia/SkiaModel.TextShaping.cs`
+
+This file provides:
+
+- HarfBuzz-based shaping
+- stable measurement for small text sizes
+- `GetTextAdvance(...)`
+- glyph run extraction
+
+This is important because `Pretext` currently measures through `SKFont.MeasureText(...)`, while `Svg.Skia` already compensates for cases where direct `MeasureText` is not stable enough.
+
+### Native and text blob caches
+
+- `src/Svg.Skia/SkiaModel.Caching.cs`
+- `src/Svg.Skia/SkiaModel.cs`
+
+Current cache coverage includes:
+
+- typeface cache
+- resolved typeface cache
+- positioned text blob cache
+- reusable native object caches
+
+### Existing tests and benchmarks
+
+High-signal text coverage already exists in:
+
+- `tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs`
+- `tests/Svg.Skia.UnitTests/SvgRetainedSceneGraphTests.cs`
+- `tests/Svg.Skia.UnitTests/W3CTestSuiteTests.cs`
+- `tests/Svg.Skia.UnitTests/resvgTests.cs`
+- `tests/Svg.Skia.Benchmarks/SvgAlignedTextPlacementBenchmarks.cs`
+- `tests/Svg.Skia.Benchmarks/SvgTextPathPlacementBenchmarks.cs`
+- `tests/Svg.Skia.Benchmarks/SvgTextAssetLoaderBenchmarks.cs`
+- `tests/Svg.Skia.Benchmarks/SvgTextCompileInternalsBenchmarks.cs`
+
+This is enough coverage to safely refactor behind an abstraction, but not enough to justify a full engine swap without staged gates.
+
+## Feature Fit Matrix
+
+### Strong fit
+
+Use `Pretext` later for these areas:
+
+- repeated measurement cache for flat text runs
+- line fitting for future wrapped-text features
+- prepared rich-inline flows in editor/UI features outside strict SVG text rendering
+- cheap line-count / natural-width probes
+- reusable segment-based measurement where text, font, whitespace, and locale remain stable
+
+### Partial fit
+
+Possible only with additional integration work:
+
+- unpositioned sequential SVG text measurement
+- logical-run preparation before final SVG placement
+- cache of flat text measurement in `Svg.SceneGraph` fast paths
+
+Requirements before this becomes safe:
+
+- injectable measurement backend
+- font resolution alignment with `SkiaSvgAssetLoader`
+- cache keys that include `SKSvgSettings` / provider context
+- target/framework/version alignment
+
+### No fit today
+
+Do not try to replace these with `Pretext`:
+
+- `textPath`
+- per-glyph `x/y/dx/dy`
+- `rotate`
+- `baseline-shift`
+- vertical writing mode
+- `glyph-orientation-vertical`
+- SVG `<font>` outline rendering
+- text decorations tied to font metrics and final glyph placement
+- clip-path text path generation
+- HarfBuzz shaping for final draw blobs
+- browser-compatible fallback run selection
+- `GetTextPath(...)` / outline generation
+
+## Feasibility Verdict
+
+### Can Pretext be the core text rendering engine?
+
+No.
+
+It should not replace the rendering core in `Svg.Skia`.
+
+Reasons:
+
+- it does not render
+- it does not build outlines
+- it does not own shaping for final draw output
+- it does not know about SVG placement semantics
+- it cannot represent the current fallback/typeface-provider model
+
+### Can Pretext be the core text layout and measurement-cache layer?
+
+Yes, but only for a constrained sub-problem and only after prerequisites are met.
+
+The realistic adoption boundary is:
+
+- prepared measurement and line-fit cache for flat text
+- optional helper for future wrapped or editor-oriented text
+- possibly a net10-only experimental path first
+
+It is not realistic to replace "most" of the text engine without preserving a large SVG-specific layer above it.
+
+The correct architecture is:
+
+- `Pretext` for preparation / reusable measurement / line fitting
+- `Svg.Skia` for SVG semantics, shaping, fallback resolution, placement, drawing, and path generation
+
+## Hard Blockers
+
+### 1. Target framework mismatch
+
+Current state:
+
+- `Pretext`: `net10.0`
+- `Svg.Skia`: `netstandard2.0;net461;net6.0;net8.0;net10.0`
+
+Impact:
+
+- any direct integration would be net10-only
+- package consumers on the other targets would need fallback code anyway
+
+Required resolution:
+
+- either multi-target `Pretext`
+- or isolate all `Pretext` usage behind net10-only optional code paths
+
+### 2. SkiaSharp major-version mismatch
+
+Current state:
+
+- `Pretext`: `SkiaSharp 3.119.1`
+- `Svg.Skia`: `SkiaSharp 2.88.9`
+
+Impact:
+
+- direct package/reference integration is not safe
+- this is a real adoption blocker, not a cleanup detail
+
+Required resolution:
+
+- either migrate `Svg.Skia` to SkiaSharp 3.x
+- or produce a `Pretext` build compatible with SkiaSharp 2.88.x
+
+### 3. Measurement backend mismatch
+
+Current state:
+
+- `Pretext` measures from font strings and `SKFont.MeasureText(...)`
+- `Svg.Skia` measures through `SkiaSvgAssetLoader`, HarfBuzz shaping, stable small-size measurement, and custom fallback/typeface-provider logic
+
+Impact:
+
+- same font string can still produce different effective glyph coverage and advance behavior
+- `Pretext` cache keys are not rich enough for `Svg.Skia` settings
+
+Required resolution:
+
+- public pluggable measurement backend in `Pretext`
+- cache keys that include provider context or a caller-supplied engine identity
+
+### 4. SVG semantic mismatch
+
+`Pretext` does not model:
+
+- SVG text tree flattening rules
+- `tspan` inheritance and nested positioning
+- `textPath`
+- `textLength`
+- `letter-spacing` / `word-spacing` behavior as currently implemented
+- baseline adjustments
+- vertical glyph rotation rules
+
+Impact:
+
+- `Pretext` can only sit underneath a retained SVG-specific placement layer
+
+## Recommended Refactor Direction
+
+Do this as a layered refactor, not a rewrite.
+
+### Target architecture
+
+Split the current text engine into five explicit layers:
+
+1. **Content extraction**
+   - flatten SVG text nodes into logical text runs
+   - preserve style-source boundaries
+   - preserve SVG semantics for whitespace and references
+
+2. **Text preparation / cached measurement**
+   - prepare flat logical text with a reusable cache entry
+   - this is the future `Pretext` insertion point
+
+3. **SVG placement**
+   - apply `text-anchor`, `textLength`, spacing, `x/y/dx/dy`, `rotate`, vertical layout, `textPath`
+   - this remains `Svg.Skia`-owned
+
+4. **Rendering / outline generation**
+   - shape final runs
+   - resolve fallback typefaces
+   - draw text or build paths
+   - preserve SVG font support
+
+5. **Bounds / decorations / hit-test support**
+   - derive bounds from final placement
+   - keep decoration geometry based on final metrics
+
+### Immediate rule
+
+Only layer 2 is a valid `Pretext` integration target.
+
+## Concrete Migration Plan
+
+### Phase 0. Freeze invariants before refactor
+
+Status: required before any engine swap.
+
+Actions:
+
+- treat current text tests as compatibility gates
+- add more focused tests only if a refactor needs tighter invariants around:
+  - sequential mixed-direction runs
+  - `textLength`
+  - positioned codepoint placement
+  - `textPath`
+  - SVG font fallback
+
+Acceptance:
+
+- existing text suites stay green
+- no threshold-only regressions introduced
+
+### Phase 1. Extract a text preparation abstraction
+
+Goal:
+
+- separate preparation/cache concerns from placement/rendering concerns
+
+Create an internal abstraction similar to:
+
+- `ISvgPreparedTextEngine`
+  - `TryPrepareFlatRun(...)`
+  - `MeasureNaturalWidth(...)`
+  - `MeasureLineStats(...)`
+  - `ClearCaches(...)`
+
+Important:
+
+- the default implementation must wrap the current `Svg.Skia` measurement behavior
+- do not reference `Pretext` directly in the first extraction
+
+Acceptance:
+
+- `SvgSceneTextCompiler` no longer owns raw measurement-cache policy directly
+- existing behavior remains unchanged
+
+### Phase 2. Move flat sequential measurement behind the abstraction
+
+Scope:
+
+- sequential unpositioned text only
+- no `textPath`
+- no per-glyph coordinate lists
+- no vertical mode
+- no `textLength`
+- no SVG fonts
+
+Good first call sites:
+
+- sequential fast-path width probes
+- repeated measurement in aligned/unpositioned runs
+
+Acceptance:
+
+- no output change
+- lower code duplication between:
+  - `MeasureSequentialTextRuns(...)`
+  - `MeasureNaturalTextAdvance(...)`
+  - sequential compile fast path
+
+### Phase 3. Upstream Pretext changes required before real adoption
+
+These changes should land in `PretextSharp` before `Svg.Skia` depends on it.
+
+Required upstream work:
+
+- multi-target beyond `net10.0`
+- align SkiaSharp version with `Svg.Skia`, or vice versa
+- public measurement backend injection, not test-only internal override
+- explicit cache identity / context support
+- public API that can accept a richer font descriptor than the current CSS-like string, or a caller-supplied font resolver
+
+Strongly recommended upstream additions:
+
+- non-static engine/context instance instead of only global static caches
+- option to expose prepared grapheme advances in a way suitable for caller-owned placement engines
+- documented behavior around thread safety and cache invalidation
+
+Acceptance:
+
+- `Svg.Skia` can measure through `Pretext` without losing custom provider behavior
+
+### Phase 4. Add an experimental Pretext-backed implementation
+
+Scope:
+
+- opt-in only
+- likely `net10.0` only at first unless blockers are removed
+- flat, unpositioned, horizontal text only
+
+Use cases:
+
+- prepared cache for repeated width measurement
+- future wrapped text experiments
+
+Must not handle:
+
+- `textPath`
+- `x/y/dx/dy`
+- `rotate`
+- `baseline-shift`
+- vertical layout
+- SVG fonts
+
+Acceptance:
+
+- exact-match or near-exact parity on the approved flat-text subset
+- measurable benchmark win on repeated measurement scenarios
+
+### Phase 5. Decide the long-term boundary
+
+If the experimental path is successful, keep the long-term split as:
+
+- `Pretext`: preparation / line-fit / cached flat-text metrics
+- `Svg.Skia`: shaping, placement, fallback resolution, drawing, path generation
+
+Do not attempt to make `Pretext` the owner of the full SVG text renderer unless `Pretext` itself grows into a materially different library.
+
+## What Should Not Be Rewritten
+
+Keep these systems in `Svg.Skia`:
+
+- `SvgFontTextRenderer`
+- `SkiaSvgAssetLoader`
+- HarfBuzz shaping in `SkiaModel.TextShaping.cs`
+- `textPath` placement logic
+- positioned-codepoint placement logic
+- decoration geometry creation
+- bounds expansion based on final draw placement
+
+These are not accidental complexity. They encode SVG behavior that `Pretext` does not own.
+
+## What Can Eventually Move Behind Pretext
+
+Only these areas are realistic:
+
+- cached preparation of flat text runs
+- natural-width measurement cache
+- line statistics for future wrapped content
+- rich-inline preparation for editor/UI features outside strict SVG rendering
+
+## Proposed Acceptance Matrix For Future Implementation
+
+Before promoting any `Pretext` path from experimental to default on its supported subset, require:
+
+- all existing `SvgSceneTextCompilerTests` still pass
+- all existing retained scene graph text tests still pass
+- no regression in `W3CTestSuiteTests`
+- no regression in `resvgTests` text categories
+- benchmark win in repeated-measurement scenarios
+
+Suggested benchmark focus:
+
+- repeated measure of identical flat runs across many frames
+- repeated measure of a small set of recurring labels
+- repeated line-stat probes for stable text with changing width
+
+## Final Recommendation
+
+The right move is a **selective refactor**, not a replacement.
+
+Use `Pretext` as a future prepared-text and measurement-cache engine only after:
+
+- framework alignment
+- SkiaSharp alignment
+- pluggable measurement backend support
+- cache-context support
+
+Until those prerequisites are met, the best immediate work in `Svg.Skia` is:
+
+1. extract a preparation/cache abstraction out of `SvgSceneTextCompiler`
+2. keep the current renderer and placement engine intact
+3. integrate `Pretext` only for a narrow flat-text subset
+4. leave SVG-specific text behavior in `Svg.Skia`
+
+That path has a realistic chance of improving maintainability and repeated-measure performance without destabilizing the current SVG text feature set.

--- a/src/Svg.SceneGraph/SvgSceneTextCompiler.PreparedText.cs
+++ b/src/Svg.SceneGraph/SvgSceneTextCompiler.PreparedText.cs
@@ -72,6 +72,12 @@ internal static partial class SvgSceneTextCompiler
             SKRect geometryBounds,
             ISvgAssetLoader assetLoader);
 
+        PreparedLineStats MeasureLineStats(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader);
+
         float[] MeasureNaturalCodepointAdvances(
             SvgTextBase styleSource,
             IReadOnlyList<string> codepoints,
@@ -106,6 +112,33 @@ internal static partial class SvgSceneTextCompiler
         public float NaturalAdvance { get; }
 
         public IReadOnlyList<float> NaturalCodepointAdvances { get; }
+    }
+
+    private sealed class PreparedLineStats
+    {
+        public PreparedLineStats(
+            string drawText,
+            SKTypeface? typeface,
+            float advance,
+            SKRect relativeBounds,
+            bool usesResolvedRunTypeface)
+        {
+            DrawText = drawText;
+            Typeface = typeface;
+            Advance = advance;
+            RelativeBounds = relativeBounds;
+            UsesResolvedRunTypeface = usesResolvedRunTypeface;
+        }
+
+        public string DrawText { get; }
+
+        public SKTypeface? Typeface { get; }
+
+        public float Advance { get; }
+
+        public SKRect RelativeBounds { get; }
+
+        public bool UsesResolvedRunTypeface { get; }
     }
 
     private sealed record PreparedSequentialRun(
@@ -189,6 +222,15 @@ internal static partial class SvgSceneTextCompiler
             return MeasureNaturalTextAdvanceCore(styleSource, text, geometryBounds, assetLoader);
         }
 
+        public PreparedLineStats MeasureLineStats(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader)
+        {
+            return MeasureLineStatsCore(styleSource, text, geometryBounds, assetLoader);
+        }
+
         public float[] MeasureNaturalCodepointAdvances(
             SvgTextBase styleSource,
             IReadOnlyList<string> codepoints,
@@ -233,7 +275,7 @@ internal static partial class SvgSceneTextCompiler
     {
         preparedText = null;
 
-        if (HasSequentialTextRunBarriers(svgTextBase) ||
+        if (HasPreparedSequentialTextContainerBarriers(svgTextBase) ||
             !TryCollectSequentialTextRuns(svgTextBase, requireAnchorContent: false, IsTextReferenceRenderingEnabled(assetLoader), trimLeadingWhitespaceAtStart, out var runs))
         {
             return false;
@@ -248,7 +290,8 @@ internal static partial class SvgSceneTextCompiler
         ISvgAssetLoader assetLoader,
         out PreparedSequentialText? preparedText)
     {
-        if (!s_preparedTextEngine.TryPrepareSequentialText(runs, geometryBounds, assetLoader, out var prepared) ||
+        if (!CanPrepareSequentialTextRuns(runs, geometryBounds, assetLoader) ||
+            !s_preparedTextEngine.TryPrepareSequentialText(runs, geometryBounds, assetLoader, out var prepared) ||
             prepared.Runs.Count != runs.Count)
         {
             preparedText = null;
@@ -257,6 +300,51 @@ internal static partial class SvgSceneTextCompiler
 
         preparedText = prepared;
         return true;
+    }
+
+    private static PreparedLineStats MeasureLineStats(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        return s_preparedTextEngine.MeasureLineStats(svgTextBase, text, geometryBounds, assetLoader);
+    }
+
+    private static bool CanPrepareSequentialTextRuns(
+        IReadOnlyList<SequentialTextRun> runs,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        if (runs.Count == 0)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < runs.Count; i++)
+        {
+            if (!CanPrepareSequentialTextRun(runs[i], geometryBounds, assetLoader))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool CanPrepareSequentialTextRun(
+        SequentialTextRun run,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        if (IsVerticalWritingMode(run.StyleSource) ||
+            HasOwnTextLengthAdjustment(run.StyleSource))
+        {
+            return false;
+        }
+
+        var paint = CreateTextMetricsPaint(run.StyleSource, geometryBounds);
+        return !SvgFontTextRenderer.TryGetLayout(run.StyleSource, run.Text, paint, assetLoader, out _);
     }
 
     private static void ClearPreparedTextCaches()
@@ -396,5 +484,106 @@ internal static partial class SvgSceneTextCompiler
         }
 
         return MeasureNaturalTextAdvanceHorizontal(svgTextBase, text, geometryBounds, assetLoader);
+    }
+
+    private static PreparedLineStats MeasureLineStatsCore(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        var paint = CreateTextMetricsPaint(svgTextBase, geometryBounds);
+        var fallbackText = GetBrowserCompatibleFallbackText(svgTextBase, text, assetLoader);
+        if (string.IsNullOrEmpty(fallbackText))
+        {
+            return new PreparedLineStats(string.Empty, paint.Typeface, 0f, SKRect.Empty, usesResolvedRunTypeface: false);
+        }
+
+        if (TryCreateBrowserCompatibleFullRunPaint(svgTextBase, fallbackText, paint, assetLoader, out var fullRunPaint, out var shapedText))
+        {
+            var measureBounds = new SKRect();
+            var advance = EnsureWhitespaceAdvance(
+                fallbackText,
+                fullRunPaint,
+                assetLoader,
+                assetLoader.MeasureText(shapedText, fullRunPaint, ref measureBounds));
+            var relativeBounds = measureBounds;
+            if (relativeBounds.IsEmpty)
+            {
+                relativeBounds = GetTextAdvanceBox(svgTextBase, 0f, 0f, advance, fullRunPaint, assetLoader);
+            }
+            else
+            {
+                relativeBounds = ExpandTextBoundsWithAdvanceBox(svgTextBase, relativeBounds, 0f, 0f, advance, fullRunPaint, assetLoader);
+            }
+
+            return new PreparedLineStats(shapedText, fullRunPaint.Typeface, advance, relativeBounds, usesResolvedRunTypeface: true);
+        }
+
+        var spans = assetLoader.FindTypefaces(fallbackText, paint);
+        if (spans.Count > 0)
+        {
+            var currentX = 0f;
+            var totalAdvance = 0f;
+            var bounds = SKRect.Empty;
+            for (var i = 0; i < spans.Count; i++)
+            {
+                var localPaint = paint.Clone();
+                localPaint.Typeface = spans[i].Typeface;
+
+                var spanBounds = SKRect.Empty;
+                var spanMeasureBounds = new SKRect();
+                var measuredAdvance = assetLoader.MeasureText(spans[i].Text, localPaint, ref spanMeasureBounds);
+                if (!spanMeasureBounds.IsEmpty)
+                {
+                    spanBounds = spanMeasureBounds;
+                }
+                else if (TryGetRenderedTextLocalBounds(spans[i].Text, localPaint, assetLoader, out var renderedBounds))
+                {
+                    spanBounds = renderedBounds;
+                }
+
+                var spanAdvance = EnsureWhitespaceAdvance(spans[i].Text, localPaint, assetLoader, spans[i].Advance > 0f ? spans[i].Advance : measuredAdvance);
+                if (!spanBounds.IsEmpty)
+                {
+                    UnionBounds(ref bounds, new SKRect(
+                        currentX + spanBounds.Left,
+                        spanBounds.Top,
+                        currentX + spanBounds.Right,
+                        spanBounds.Bottom));
+                }
+
+                UnionBounds(ref bounds, GetTextAdvanceBox(svgTextBase, currentX, 0f, spanAdvance, localPaint, assetLoader));
+                currentX += spanAdvance;
+                totalAdvance += spanAdvance;
+            }
+
+            return new PreparedLineStats(
+                ApplyBrowserCompatibleBidiControls(svgTextBase, fallbackText),
+                paint.Typeface,
+                totalAdvance,
+                bounds,
+                usesResolvedRunTypeface: false);
+        }
+
+        var fallbackMeasureBounds = new SKRect();
+        var advanceWithoutTypefaceSpans = EnsureWhitespaceAdvance(fallbackText, paint, assetLoader, assetLoader.MeasureText(fallbackText, paint, ref fallbackMeasureBounds));
+        var relativeFallbackBounds = fallbackMeasureBounds;
+        if (relativeFallbackBounds.IsEmpty &&
+            !TryGetRenderedTextLocalBounds(fallbackText, paint, assetLoader, out relativeFallbackBounds))
+        {
+            relativeFallbackBounds = GetTextAdvanceBox(svgTextBase, 0f, 0f, advanceWithoutTypefaceSpans, paint, assetLoader);
+        }
+        else
+        {
+            relativeFallbackBounds = ExpandTextBoundsWithAdvanceBox(svgTextBase, relativeFallbackBounds, 0f, 0f, advanceWithoutTypefaceSpans, paint, assetLoader);
+        }
+
+        return new PreparedLineStats(
+            ApplyBrowserCompatibleBidiControls(svgTextBase, fallbackText),
+            paint.Typeface,
+            advanceWithoutTypefaceSpans,
+            relativeFallbackBounds,
+            usesResolvedRunTypeface: false);
     }
 }

--- a/src/Svg.SceneGraph/SvgSceneTextCompiler.PreparedText.cs
+++ b/src/Svg.SceneGraph/SvgSceneTextCompiler.PreparedText.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using ShimSkiaSharp;
+using Svg.Model;
+using Svg.Model.Services;
+
+namespace Svg.Skia;
+
+internal static partial class SvgSceneTextCompiler
+{
+    private static readonly ConcurrentDictionary<SimpleCodepointAdvanceCacheKey, float> s_simpleCodepointAdvanceCache = new();
+    private static readonly ConcurrentDictionary<NaturalCodepointAdvanceCacheKey, float[]> s_naturalCodepointAdvanceCache = new();
+    private const int SimpleCodepointAdvanceCacheLimit = 4096;
+    private const int NaturalCodepointAdvanceCacheLimit = 1024;
+
+    private readonly record struct SimpleCodepointAdvanceCacheKey(
+        int AssetLoaderId,
+        string Codepoint,
+        float TextSize,
+        bool LcdRenderText,
+        bool SubpixelText,
+        SKTextEncoding TextEncoding,
+        string? TypefaceFamilyName,
+        SKFontStyleWeight TypefaceWeight,
+        SKFontStyleWidth TypefaceWidth,
+        SKFontStyleSlant TypefaceSlant);
+
+    private readonly record struct NaturalCodepointAdvanceCacheKey(
+        int AssetLoaderId,
+        string Text,
+        float TextSize,
+        bool LcdRenderText,
+        bool SubpixelText,
+        SKTextEncoding TextEncoding,
+        string? TypefaceFamilyName,
+        SKFontStyleWeight TypefaceWeight,
+        SKFontStyleWidth TypefaceWidth,
+        SKFontStyleSlant TypefaceSlant,
+        bool RightToLeft,
+        bool RequiresSyntheticSmallCaps,
+        bool UsesBrowserCompatibleRunTypeface);
+
+    // Keep flat sequential text preparation behind a swappable boundary so a future
+    // Pretext-backed implementation can plug in without taking ownership of SVG placement.
+    private interface ISvgPreparedTextEngine
+    {
+        bool TryPrepareFlatRun(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader,
+            out PreparedFlatTextRun preparedText);
+
+        bool TryPrepareSequentialText(
+            IReadOnlyList<SequentialTextRun> runs,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader,
+            out PreparedSequentialText preparedText);
+
+        float MeasureAdvance(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader);
+
+        float MeasureNaturalWidth(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader);
+
+        float[] MeasureNaturalCodepointAdvances(
+            SvgTextBase styleSource,
+            IReadOnlyList<string> codepoints,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader);
+
+        void ClearCaches();
+    }
+
+    private sealed class PreparedFlatTextRun
+    {
+        public PreparedFlatTextRun(
+            SvgTextBase styleSource,
+            string text,
+            float advance,
+            float naturalAdvance,
+            float[] naturalCodepointAdvances)
+        {
+            StyleSource = styleSource;
+            Text = text;
+            Advance = advance;
+            NaturalAdvance = naturalAdvance;
+            NaturalCodepointAdvances = naturalCodepointAdvances;
+        }
+
+        public SvgTextBase StyleSource { get; }
+
+        public string Text { get; }
+
+        public float Advance { get; }
+
+        public float NaturalAdvance { get; }
+
+        public IReadOnlyList<float> NaturalCodepointAdvances { get; }
+    }
+
+    private sealed record PreparedSequentialRun(
+        SvgTextBase StyleSource,
+        string Text,
+        float Advance);
+
+    private sealed class PreparedSequentialText
+    {
+        public PreparedSequentialText(PreparedSequentialRun[] runs, float totalAdvance)
+        {
+            Runs = runs;
+            TotalAdvance = totalAdvance;
+        }
+
+        public IReadOnlyList<PreparedSequentialRun> Runs { get; }
+
+        public float TotalAdvance { get; }
+    }
+
+    private sealed class CurrentSvgPreparedTextEngine : ISvgPreparedTextEngine
+    {
+        public bool TryPrepareFlatRun(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader,
+            out PreparedFlatTextRun preparedText)
+        {
+            var naturalCodepointAdvances = MeasureNaturalCodepointAdvancesCore(styleSource, SplitCodepoints(text), geometryBounds, assetLoader);
+            preparedText = new PreparedFlatTextRun(
+                styleSource,
+                text,
+                MeasureTextAdvanceCore(styleSource, text, geometryBounds, assetLoader),
+                MeasureNaturalTextAdvanceCore(styleSource, text, geometryBounds, assetLoader),
+                naturalCodepointAdvances);
+            return true;
+        }
+
+        public bool TryPrepareSequentialText(
+            IReadOnlyList<SequentialTextRun> runs,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader,
+            out PreparedSequentialText preparedText)
+        {
+            if (runs.Count == 0)
+            {
+                preparedText = null!;
+                return false;
+            }
+
+            var preparedRuns = new PreparedSequentialRun[runs.Count];
+            var totalAdvance = 0f;
+            for (var i = 0; i < runs.Count; i++)
+            {
+                var run = runs[i];
+                var advance = MeasureTextAdvanceCore(run.StyleSource, run.Text, geometryBounds, assetLoader);
+                preparedRuns[i] = new PreparedSequentialRun(run.StyleSource, run.Text, advance);
+                totalAdvance += advance;
+            }
+
+            preparedText = new PreparedSequentialText(preparedRuns, totalAdvance);
+            return true;
+        }
+
+        public float MeasureAdvance(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader)
+        {
+            return MeasureTextAdvanceCore(styleSource, text, geometryBounds, assetLoader);
+        }
+
+        public float MeasureNaturalWidth(
+            SvgTextBase styleSource,
+            string text,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader)
+        {
+            return MeasureNaturalTextAdvanceCore(styleSource, text, geometryBounds, assetLoader);
+        }
+
+        public float[] MeasureNaturalCodepointAdvances(
+            SvgTextBase styleSource,
+            IReadOnlyList<string> codepoints,
+            SKRect geometryBounds,
+            ISvgAssetLoader assetLoader)
+        {
+            return MeasureNaturalCodepointAdvancesCore(styleSource, codepoints, geometryBounds, assetLoader);
+        }
+
+        public void ClearCaches()
+        {
+            s_simpleCodepointAdvanceCache.Clear();
+            s_naturalCodepointAdvanceCache.Clear();
+        }
+    }
+
+    private static readonly ISvgPreparedTextEngine s_preparedTextEngine = new CurrentSvgPreparedTextEngine();
+
+    private static bool TryPrepareFlatTextRun(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader,
+        out PreparedFlatTextRun? preparedText)
+    {
+        if (!s_preparedTextEngine.TryPrepareFlatRun(svgTextBase, text, geometryBounds, assetLoader, out var prepared))
+        {
+            preparedText = null;
+            return false;
+        }
+
+        preparedText = prepared;
+        return true;
+    }
+
+    private static bool TryPrepareSequentialTextRuns(
+        SvgTextBase svgTextBase,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader,
+        bool trimLeadingWhitespaceAtStart,
+        out PreparedSequentialText? preparedText)
+    {
+        preparedText = null;
+
+        if (HasSequentialTextRunBarriers(svgTextBase) ||
+            !TryCollectSequentialTextRuns(svgTextBase, requireAnchorContent: false, IsTextReferenceRenderingEnabled(assetLoader), trimLeadingWhitespaceAtStart, out var runs))
+        {
+            return false;
+        }
+
+        return TryPrepareSequentialTextRuns(runs, geometryBounds, assetLoader, out preparedText);
+    }
+
+    private static bool TryPrepareSequentialTextRuns(
+        IReadOnlyList<SequentialTextRun> runs,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader,
+        out PreparedSequentialText? preparedText)
+    {
+        if (!s_preparedTextEngine.TryPrepareSequentialText(runs, geometryBounds, assetLoader, out var prepared) ||
+            prepared.Runs.Count != runs.Count)
+        {
+            preparedText = null;
+            return false;
+        }
+
+        preparedText = prepared;
+        return true;
+    }
+
+    private static void ClearPreparedTextCaches()
+    {
+        s_preparedTextEngine.ClearCaches();
+    }
+
+    private static float[] MeasureNaturalCodepointAdvancesCore(
+        SvgTextBase svgTextBase,
+        IReadOnlyList<string> codepoints,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        var advances = new float[codepoints.Count];
+        if (codepoints.Count == 0)
+        {
+            return advances;
+        }
+
+        if (IsVerticalWritingMode(svgTextBase))
+        {
+            for (var i = 0; i < codepoints.Count; i++)
+            {
+                advances[i] = MeasureNaturalTextAdvanceCore(svgTextBase, codepoints[i], geometryBounds, assetLoader);
+            }
+
+            return advances;
+        }
+
+        var text = string.Concat(codepoints);
+        if (string.IsNullOrEmpty(text))
+        {
+            return advances;
+        }
+
+        var paint = new SKPaint();
+        PaintingService.SetPaintText(svgTextBase, geometryBounds, paint);
+        paint.TextAlign = SKTextAlign.Left;
+
+        var isRightToLeft = IsRightToLeft(svgTextBase);
+        var requiresSyntheticSmallCaps = RequiresSyntheticSmallCaps(svgTextBase, text);
+        var usesBrowserCompatibleRunTypeface = ShouldUseBrowserCompatibleRunTypeface(svgTextBase, text);
+        var cacheKey = CreateNaturalCodepointAdvanceCacheKey(
+            assetLoader,
+            text,
+            paint,
+            isRightToLeft,
+            requiresSyntheticSmallCaps,
+            usesBrowserCompatibleRunTypeface);
+        if (TryGetCachedNaturalCodepointAdvances(cacheKey, out var cachedAdvances))
+        {
+            return cachedAdvances;
+        }
+
+        if (TryMeasureNaturalCodepointAdvancesFromSimpleShapedRun(
+                svgTextBase,
+                text,
+                codepoints,
+                geometryBounds,
+                paint,
+                assetLoader,
+                isRightToLeft,
+                requiresSyntheticSmallCaps,
+                usesBrowserCompatibleRunTypeface,
+                out var shapedAdvances))
+        {
+            CacheNaturalCodepointAdvances(cacheKey, shapedAdvances);
+            return shapedAdvances;
+        }
+
+        var builder = new StringBuilder();
+        var previousAdvance = 0f;
+
+        for (var i = 0; i < codepoints.Count; i++)
+        {
+            var prefixText = builder.ToString();
+            builder.Append(codepoints[i]);
+            var currentAdvance = MeasureNaturalTextAdvanceCore(svgTextBase, builder.ToString(), geometryBounds, assetLoader);
+            var codepointAdvance = currentAdvance - previousAdvance;
+            if (IsWhitespaceCodepoint(codepoints[i]))
+            {
+                var contextualWhitespaceAdvance = MeasureContextualWhitespaceAdvance(svgTextBase, prefixText, codepoints[i], geometryBounds, assetLoader);
+                if (IsValidPositiveAdvance(contextualWhitespaceAdvance))
+                {
+                    codepointAdvance = contextualWhitespaceAdvance;
+                }
+            }
+
+            if (!IsValidPositiveAdvance(codepointAdvance))
+            {
+                codepointAdvance = 0f;
+            }
+
+            advances[i] = codepointAdvance;
+            previousAdvance += codepointAdvance;
+        }
+
+        CacheNaturalCodepointAdvances(cacheKey, advances);
+        return advances;
+    }
+
+    private static float MeasureTextAdvanceCore(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        if (TryCreateVerticalTextRunPlacements(svgTextBase, text, 0f, 0f, geometryBounds, SKTextAlign.Left, assetLoader, explicitRotations: null, out _, out var verticalAdvance))
+        {
+            return verticalAdvance;
+        }
+
+        if (TryCreateAlignedCodepointPlacements(svgTextBase, text, 0f, 0f, geometryBounds, SKTextAlign.Left, assetLoader, explicitRotations: null, out _, out var totalAdvance))
+        {
+            return totalAdvance;
+        }
+
+        return MeasureNaturalTextAdvanceCore(svgTextBase, text, geometryBounds, assetLoader);
+    }
+
+    private static float MeasureNaturalTextAdvanceCore(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        if (IsVerticalWritingMode(svgTextBase))
+        {
+            var codepoints = SplitCodepoints(text);
+            var totalAdvance = 0f;
+            for (var i = 0; i < codepoints.Count; i++)
+            {
+                totalAdvance += MeasureNaturalTextAdvanceHorizontal(svgTextBase, codepoints[i], geometryBounds, assetLoader);
+            }
+
+            return totalAdvance;
+        }
+
+        return MeasureNaturalTextAdvanceHorizontal(svgTextBase, text, geometryBounds, assetLoader);
+    }
+}

--- a/src/Svg.SceneGraph/SvgSceneTextCompiler.cs
+++ b/src/Svg.SceneGraph/SvgSceneTextCompiler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -16,14 +15,10 @@ internal static partial class SvgSceneTextCompiler
 {
     private static readonly Regex s_multipleSpaces = new(@" {2,}", RegexOptions.Compiled);
     private static readonly Regex s_numberPrefix = new(@"^[+-]?(?:(?:\d+\.\d*)|(?:\d+)|(?:\.\d+))(?:[eE][+-]?\d+)?", RegexOptions.Compiled);
-    private static readonly ConcurrentDictionary<SimpleCodepointAdvanceCacheKey, float> s_simpleCodepointAdvanceCache = new();
-    private static readonly ConcurrentDictionary<NaturalCodepointAdvanceCacheKey, float[]> s_naturalCodepointAdvanceCache = new();
     private const int MaxEllipseSteps = 128;
     private const float FullCircleRadians = 2f * (float)Math.PI;
     private const float SyntheticSmallCapsScale = 0.75f;
     private const float TextLengthTolerance = 1.5f;
-    private const int SimpleCodepointAdvanceCacheLimit = 4096;
-    private const int NaturalCodepointAdvanceCacheLimit = 1024;
     private const string RawTextDecorationAttributeKey = "__svgskia:text-decoration-raw";
 
     private readonly record struct SequentialTextRun(SvgTextBase StyleSource, string Text);
@@ -48,33 +43,6 @@ internal static partial class SvgSceneTextCompiler
     private readonly record struct PathSample(SKPoint Point, float Distance, bool StartsSubpath);
 
     private readonly record struct ResolvedFallbackCodepoint(string Text, SKPaint Paint, float Advance);
-
-    private readonly record struct SimpleCodepointAdvanceCacheKey(
-        int AssetLoaderId,
-        string Codepoint,
-        float TextSize,
-        bool LcdRenderText,
-        bool SubpixelText,
-        SKTextEncoding TextEncoding,
-        string? TypefaceFamilyName,
-        SKFontStyleWeight TypefaceWeight,
-        SKFontStyleWidth TypefaceWidth,
-        SKFontStyleSlant TypefaceSlant);
-
-    private readonly record struct NaturalCodepointAdvanceCacheKey(
-        int AssetLoaderId,
-        string Text,
-        float TextSize,
-        bool LcdRenderText,
-        bool SubpixelText,
-        SKTextEncoding TextEncoding,
-        string? TypefaceFamilyName,
-        SKFontStyleWeight TypefaceWeight,
-        SKFontStyleWidth TypefaceWidth,
-        SKFontStyleSlant TypefaceSlant,
-        bool RightToLeft,
-        bool RequiresSyntheticSmallCaps,
-        bool UsesBrowserCompatibleRunTypeface);
 
     private readonly record struct PositionedCodepointPlacement(SKPoint Point, float RotationDegrees, float ScaleX, float ScaleOriginX);
 
@@ -705,6 +673,7 @@ internal static partial class SvgSceneTextCompiler
             return false;
         }
 
+        PreparedSequentialText? preparedText = null;
         ApplyInitialSequentialOffsets(svgTextBase, viewport, ref currentX, ref currentY);
         var isVertical = IsVerticalWritingMode(svgTextBase);
         var textAlign = GetTextAnchorAlign(svgTextBase, geometryBounds);
@@ -722,14 +691,21 @@ internal static partial class SvgSceneTextCompiler
             return true;
         }
 
-        var totalAdvance = MeasureSequentialTextRuns(runs, geometryBounds, assetLoader);
+        if (!TryPrepareSequentialTextRuns(runs, geometryBounds, assetLoader, out preparedText) ||
+            preparedText is null)
+        {
+            return false;
+        }
+
+        var totalAdvance = preparedText.TotalAdvance;
         var inlineOrigin = GetAlignedStartCoordinate(isVertical ? currentY : currentX, totalAdvance, textAlign);
         var drawX = isVertical ? currentX : inlineOrigin;
         var drawY = isVertical ? inlineOrigin : currentY;
 
-        for (var i = 0; i < runs.Count; i++)
+        for (var i = 0; i < preparedText.Runs.Count; i++)
         {
-            AppendTextStringPathAlignedLeft(runs[i].StyleSource, runs[i].Text, ref drawX, ref drawY, geometryBounds, assetLoader, path);
+            var preparedRun = preparedText.Runs[i];
+            AppendTextStringPathAlignedLeft(preparedRun.StyleSource, preparedRun.Text, ref drawX, ref drawY, geometryBounds, assetLoader, path);
         }
 
         if (isVertical)
@@ -4478,14 +4454,21 @@ internal static partial class SvgSceneTextCompiler
             return true;
         }
 
-        var totalAdvance = MeasureSequentialTextRuns(runs, geometryBounds, assetLoader);
+        if (!TryPrepareSequentialTextRuns(runs, geometryBounds, assetLoader, out var preparedText) ||
+            preparedText is null)
+        {
+            return false;
+        }
+
+        var totalAdvance = preparedText.TotalAdvance;
         var inlineOrigin = GetAlignedStartCoordinate(isVertical ? currentY : currentX, totalAdvance, textAlign);
         var drawX = isVertical ? currentX : inlineOrigin;
         var drawY = isVertical ? inlineOrigin : currentY;
 
-        for (var i = 0; i < runs.Count; i++)
+        for (var i = 0; i < preparedText.Runs.Count; i++)
         {
-            DrawTextStringAlignedLeft(runs[i].StyleSource, runs[i].Text, ref drawX, ref drawY, geometryBounds, ignoreAttributes, canvas, assetLoader);
+            var preparedRun = preparedText.Runs[i];
+            DrawTextStringAlignedLeft(preparedRun.StyleSource, preparedRun.Text, ref drawX, ref drawY, geometryBounds, ignoreAttributes, canvas, assetLoader);
         }
 
         if (isVertical)
@@ -4526,6 +4509,12 @@ internal static partial class SvgSceneTextCompiler
             return true;
         }
 
+        if (!TryPrepareSequentialTextRuns(runs, viewport, assetLoader, out var preparedText) ||
+            preparedText is null)
+        {
+            return false;
+        }
+
         ApplyInitialSequentialOffsets(svgTextBase, viewport, ref currentX, ref currentY);
         var isVertical = IsVerticalWritingMode(svgTextBase);
         var textAlign = GetTextAnchorAlign(svgTextBase, viewport);
@@ -4533,11 +4522,12 @@ internal static partial class SvgSceneTextCompiler
         {
             var startAlignedX = currentX;
             var startAlignedY = currentY;
-            for (var i = 0; i < runs.Count; i++)
+            for (var i = 0; i < preparedText.Runs.Count; i++)
             {
-                var runBounds = MeasureTextStringBoundsAlignedLeft(runs[i].StyleSource, runs[i].Text, startAlignedX, startAlignedY, viewport, assetLoader, rotations: null, out var runAdvance);
+                var preparedRun = preparedText.Runs[i];
+                var runBounds = MeasureTextStringBoundsAlignedLeft(preparedRun.StyleSource, preparedRun.Text, startAlignedX, startAlignedY, viewport, assetLoader, rotations: null, out _);
                 UnionBounds(ref bounds, runBounds);
-                ApplyInlineAdvance(runs[i].StyleSource, ref startAlignedX, ref startAlignedY, runAdvance);
+                ApplyInlineAdvance(preparedRun.StyleSource, ref startAlignedX, ref startAlignedY, preparedRun.Advance);
             }
 
             currentX = startAlignedX;
@@ -4545,16 +4535,17 @@ internal static partial class SvgSceneTextCompiler
             return true;
         }
 
-        var totalAdvance = MeasureSequentialTextRuns(runs, viewport, assetLoader);
+        var totalAdvance = preparedText.TotalAdvance;
         var inlineOrigin = GetAlignedStartCoordinate(isVertical ? currentY : currentX, totalAdvance, textAlign);
         var drawX = isVertical ? currentX : inlineOrigin;
         var drawY = isVertical ? inlineOrigin : currentY;
 
-        for (var i = 0; i < runs.Count; i++)
+        for (var i = 0; i < preparedText.Runs.Count; i++)
         {
-            var runBounds = MeasureTextStringBoundsAlignedLeft(runs[i].StyleSource, runs[i].Text, drawX, drawY, viewport, assetLoader, rotations: null, out var runAdvance);
+            var preparedRun = preparedText.Runs[i];
+            var runBounds = MeasureTextStringBoundsAlignedLeft(preparedRun.StyleSource, preparedRun.Text, drawX, drawY, viewport, assetLoader, rotations: null, out _);
             UnionBounds(ref bounds, runBounds);
-            ApplyInlineAdvance(runs[i].StyleSource, ref drawX, ref drawY, runAdvance);
+            ApplyInlineAdvance(preparedRun.StyleSource, ref drawX, ref drawY, preparedRun.Advance);
         }
 
         if (isVertical)
@@ -7080,92 +7071,7 @@ internal static partial class SvgSceneTextCompiler
         SKRect geometryBounds,
         ISvgAssetLoader assetLoader)
     {
-        var advances = new float[codepoints.Count];
-        if (codepoints.Count == 0)
-        {
-            return advances;
-        }
-
-        if (IsVerticalWritingMode(svgTextBase))
-        {
-            for (var i = 0; i < codepoints.Count; i++)
-            {
-                advances[i] = MeasureNaturalTextAdvance(svgTextBase, codepoints[i], geometryBounds, assetLoader);
-            }
-
-            return advances;
-        }
-
-        var text = string.Concat(codepoints);
-        if (string.IsNullOrEmpty(text))
-        {
-            return advances;
-        }
-
-        var paint = new SKPaint();
-        PaintingService.SetPaintText(svgTextBase, geometryBounds, paint);
-        paint.TextAlign = SKTextAlign.Left;
-
-        var isRightToLeft = IsRightToLeft(svgTextBase);
-        var requiresSyntheticSmallCaps = RequiresSyntheticSmallCaps(svgTextBase, text);
-        var usesBrowserCompatibleRunTypeface = ShouldUseBrowserCompatibleRunTypeface(svgTextBase, text);
-        var cacheKey = CreateNaturalCodepointAdvanceCacheKey(
-            assetLoader,
-            text,
-            paint,
-            isRightToLeft,
-            requiresSyntheticSmallCaps,
-            usesBrowserCompatibleRunTypeface);
-        if (TryGetCachedNaturalCodepointAdvances(cacheKey, out var cachedAdvances))
-        {
-            return cachedAdvances;
-        }
-
-        if (TryMeasureNaturalCodepointAdvancesFromSimpleShapedRun(
-                svgTextBase,
-                text,
-                codepoints,
-                geometryBounds,
-                paint,
-                assetLoader,
-                isRightToLeft,
-                requiresSyntheticSmallCaps,
-                usesBrowserCompatibleRunTypeface,
-                out var shapedAdvances))
-        {
-            CacheNaturalCodepointAdvances(cacheKey, shapedAdvances);
-            return shapedAdvances;
-        }
-
-        var builder = new StringBuilder();
-        var previousAdvance = 0f;
-
-        for (var i = 0; i < codepoints.Count; i++)
-        {
-            var prefixText = builder.ToString();
-            builder.Append(codepoints[i]);
-            var currentAdvance = MeasureNaturalTextAdvance(svgTextBase, builder.ToString(), geometryBounds, assetLoader);
-            var codepointAdvance = currentAdvance - previousAdvance;
-            if (IsWhitespaceCodepoint(codepoints[i]))
-            {
-                var contextualWhitespaceAdvance = MeasureContextualWhitespaceAdvance(svgTextBase, prefixText, codepoints[i], geometryBounds, assetLoader);
-                if (IsValidPositiveAdvance(contextualWhitespaceAdvance))
-                {
-                    codepointAdvance = contextualWhitespaceAdvance;
-                }
-            }
-
-            if (!IsValidPositiveAdvance(codepointAdvance))
-            {
-                codepointAdvance = 0f;
-            }
-
-            advances[i] = codepointAdvance;
-            previousAdvance += codepointAdvance;
-        }
-
-        CacheNaturalCodepointAdvances(cacheKey, advances);
-        return advances;
+        return s_preparedTextEngine.MeasureNaturalCodepointAdvances(svgTextBase, codepoints, geometryBounds, assetLoader);
     }
 
     private static bool TryMeasureNaturalCodepointAdvancesFromSimpleShapedRun(
@@ -7872,10 +7778,16 @@ internal static partial class SvgSceneTextCompiler
         SKRect geometryBounds,
         ISvgAssetLoader assetLoader)
     {
+        if (TryPrepareSequentialTextRuns(runs, geometryBounds, assetLoader, out var preparedText) &&
+            preparedText is not null)
+        {
+            return preparedText.TotalAdvance;
+        }
+
         var totalAdvance = 0f;
         for (var i = 0; i < runs.Count; i++)
         {
-            totalAdvance += MeasureTextAdvance(runs[i].StyleSource, runs[i].Text, geometryBounds, assetLoader);
+            totalAdvance += s_preparedTextEngine.MeasureAdvance(runs[i].StyleSource, runs[i].Text, geometryBounds, assetLoader);
         }
 
         return totalAdvance;
@@ -7887,17 +7799,7 @@ internal static partial class SvgSceneTextCompiler
         SKRect geometryBounds,
         ISvgAssetLoader assetLoader)
     {
-        if (TryCreateVerticalTextRunPlacements(svgTextBase, text, 0f, 0f, geometryBounds, SKTextAlign.Left, assetLoader, explicitRotations: null, out _, out var verticalAdvance))
-        {
-            return verticalAdvance;
-        }
-
-        if (TryCreateAlignedCodepointPlacements(svgTextBase, text, 0f, 0f, geometryBounds, SKTextAlign.Left, assetLoader, explicitRotations: null, out _, out var totalAdvance))
-        {
-            return totalAdvance;
-        }
-
-        return MeasureNaturalTextAdvance(svgTextBase, text, geometryBounds, assetLoader);
+        return s_preparedTextEngine.MeasureAdvance(svgTextBase, text, geometryBounds, assetLoader);
     }
 
     private static float MeasureNaturalTextAdvance(
@@ -7906,19 +7808,7 @@ internal static partial class SvgSceneTextCompiler
         SKRect geometryBounds,
         ISvgAssetLoader assetLoader)
     {
-        if (IsVerticalWritingMode(svgTextBase))
-        {
-            var codepoints = SplitCodepoints(text);
-            var totalAdvance = 0f;
-            for (var i = 0; i < codepoints.Count; i++)
-            {
-                totalAdvance += MeasureNaturalTextAdvanceHorizontal(svgTextBase, codepoints[i], geometryBounds, assetLoader);
-            }
-
-            return totalAdvance;
-        }
-
-        return MeasureNaturalTextAdvanceHorizontal(svgTextBase, text, geometryBounds, assetLoader);
+        return s_preparedTextEngine.MeasureNaturalWidth(svgTextBase, text, geometryBounds, assetLoader);
     }
 
     private static float MeasureNaturalTextAdvanceHorizontal(

--- a/src/Svg.SceneGraph/SvgSceneTextCompiler.cs
+++ b/src/Svg.SceneGraph/SvgSceneTextCompiler.cs
@@ -290,11 +290,11 @@ internal static partial class SvgSceneTextCompiler
         geometryBounds = SKRect.Empty;
         localModel = null;
 
-        if (HasSequentialTextRunBarriers(svgTextBase) ||
-            IsVerticalWritingMode(svgTextBase) ||
+        if (HasPreparedSequentialTextContainerBarriers(svgTextBase) ||
             !TryCollectSequentialTextRuns(svgTextBase, requireAnchorContent: false, IsTextReferenceRenderingEnabled(assetLoader), trimLeadingWhitespaceAtStart: true, out var runs) ||
             runs.Count == 0 ||
             !CanUseSequentialCompileFastPath(runs) ||
+            !CanPrepareSequentialTextRuns(runs, viewport, assetLoader) ||
             !TryResolveSequentialCompileRuns(runs, viewport, assetLoader, out var resolvedRuns))
         {
             return false;
@@ -432,31 +432,19 @@ internal static partial class SvgSceneTextCompiler
         out ResolvedSequentialCompileRun resolvedRun)
     {
         resolvedRun = default;
-        var metricsPaint = CreateTextMetricsPaint(run.StyleSource, geometryBounds);
-        var fallbackText = GetBrowserCompatibleFallbackText(run.StyleSource, run.Text, assetLoader);
-        if (string.IsNullOrEmpty(fallbackText))
+        var lineStats = MeasureLineStats(run.StyleSource, run.Text, geometryBounds, assetLoader);
+        if (!lineStats.UsesResolvedRunTypeface ||
+            string.IsNullOrEmpty(lineStats.DrawText))
         {
             return false;
         }
 
-        if (!TryCreateBrowserCompatibleFullRunPaint(run.StyleSource, fallbackText, metricsPaint, assetLoader, out var fullRunPaint, out var shapedText))
-        {
-            return false;
-        }
-
-        var measureBounds = new SKRect();
-        var advance = EnsureWhitespaceAdvance(fallbackText, fullRunPaint, assetLoader, assetLoader.MeasureText(shapedText, fullRunPaint, ref measureBounds));
-        var relativeBounds = measureBounds;
-        if (relativeBounds.IsEmpty)
-        {
-            relativeBounds = GetTextAdvanceBox(run.StyleSource, 0f, 0f, advance, fullRunPaint, assetLoader);
-        }
-        else
-        {
-            relativeBounds = ExpandTextBoundsWithAdvanceBox(run.StyleSource, relativeBounds, 0f, 0f, advance, fullRunPaint, assetLoader);
-        }
-
-        resolvedRun = new ResolvedSequentialCompileRun(run.StyleSource, shapedText, fullRunPaint.Typeface, advance, relativeBounds);
+        resolvedRun = new ResolvedSequentialCompileRun(
+            run.StyleSource,
+            lineStats.DrawText,
+            lineStats.Typeface,
+            lineStats.Advance,
+            lineStats.RelativeBounds);
         return true;
     }
 
@@ -663,7 +651,7 @@ internal static partial class SvgSceneTextCompiler
         SKPath path,
         bool trimLeadingWhitespaceAtStart)
     {
-        if (HasSequentialTextRunBarriers(svgTextBase))
+        if (HasPreparedSequentialTextContainerBarriers(svgTextBase))
         {
             return false;
         }
@@ -4422,7 +4410,7 @@ internal static partial class SvgSceneTextCompiler
         ISvgAssetLoader assetLoader,
         bool trimLeadingWhitespaceAtStart)
     {
-        if (HasSequentialTextRunBarriers(svgTextBase))
+        if (HasPreparedSequentialTextContainerBarriers(svgTextBase))
         {
             return false;
         }
@@ -4494,7 +4482,7 @@ internal static partial class SvgSceneTextCompiler
         ref SKRect bounds,
         bool trimLeadingWhitespaceAtStart)
     {
-        if (HasSequentialTextRunBarriers(svgTextBase))
+        if (HasPreparedSequentialTextContainerBarriers(svgTextBase))
         {
             return false;
         }
@@ -6848,6 +6836,33 @@ internal static partial class SvgSceneTextCompiler
         }
 
         return true;
+    }
+
+    private static bool HasPreparedSequentialTextContainerBarriers(SvgTextBase svgTextBase)
+    {
+        return HasSequentialTextRunBarriers(svgTextBase) ||
+               ContainsPreparedSequentialTextSubtreeBarrier(svgTextBase);
+    }
+
+    private static bool ContainsPreparedSequentialTextSubtreeBarrier(SvgTextBase svgTextBase)
+    {
+        if (IsVerticalWritingMode(svgTextBase) ||
+            HasOwnTextLengthAdjustment(svgTextBase))
+        {
+            return true;
+        }
+
+        foreach (var node in GetContentNodes(svgTextBase))
+        {
+            if (node is SvgTextBase childTextBase &&
+                CanRenderTextSubtree(childTextBase) &&
+                ContainsPreparedSequentialTextSubtreeBarrier(childTextBase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsTextReferenceRenderingEnabled(ISvgAssetLoader assetLoader)

--- a/tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs
+++ b/tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs
@@ -193,6 +193,42 @@ public class SvgSceneTextCompilerTests
     }
 
     [Fact]
+    public void TryCompileSequentialText_Succeeds_ForDirectedAsciiRuns()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24" direction="rtl" unicode-bidi="embed">ABC<tspan font-weight="bold">DEF</tspan></text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var viewport = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var succeeded = InvokeTryCompileSequentialText(svgText, viewport, assetLoader);
+
+        Assert.True(succeeded);
+    }
+
+    [Fact]
+    public void TryCompileSequentialText_FallsBack_ForNestedTextLengthAdjustment()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">A<tspan textLength="120"><tspan>BC</tspan></tspan>D</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var viewport = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var succeeded = InvokeTryCompileSequentialText(svgText, viewport, assetLoader);
+
+        Assert.False(succeeded);
+    }
+
+    [Fact]
     public void TryPrepareFlatTextRun_ReturnsPreparedNaturalMetrics_ForSimpleText()
     {
         var document = CreateDocument("AVATAR ", 24);
@@ -251,6 +287,36 @@ public class SvgSceneTextCompilerTests
     }
 
     [Fact]
+    public void TryPrepareSequentialTextRuns_ReturnsPerRunAdvances_ForMixedDirectionNestedText()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">abc<tspan font-weight="bold">אבג</tspan>xyz</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.True(prepared);
+        Assert.NotNull(snapshot);
+        Assert.Collection(
+            snapshot!.Runs,
+            run => Assert.Equal("abc", run.Text),
+            run => Assert.Equal("אבג", run.Text),
+            run => Assert.Equal("xyz", run.Text));
+
+        foreach (var run in snapshot.Runs)
+        {
+            var expectedAdvance = InvokeMeasureTextAdvance(run.StyleSource, run.Text, geometryBounds, assetLoader);
+            Assert.Equal(expectedAdvance, run.Advance, 3);
+        }
+    }
+
+    [Fact]
     public void TryPrepareSequentialTextRuns_RejectsPositionedTspanBarrier()
     {
         var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
@@ -262,6 +328,93 @@ public class SvgSceneTextCompilerTests
         var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
         var geometryBounds = GetDocumentViewport(document);
         var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.False(prepared);
+        Assert.Null(snapshot);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_RejectsTextLengthAdjustment()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="240" height="80" viewBox="0 0 240 80">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24" textLength="180">a<tspan>b</tspan>c</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.False(prepared);
+        Assert.Null(snapshot);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_RejectsNestedTextLengthAdjustmentContainer()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="240" height="80" viewBox="0 0 240 80">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">a<tspan textLength="120"><tspan>b</tspan></tspan>c</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.False(prepared);
+        Assert.Null(snapshot);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_RejectsTextPathBarrier()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="320" height="120" viewBox="0 0 320 120">
+              <defs>
+                <path id="curve" d="M20 60 C 80 10, 180 10, 260 60" />
+              </defs>
+              <text id="label" font-family="sans-serif" font-size="24">
+                <textPath xlink:href="#curve">Curved text</textPath>
+              </text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.False(prepared);
+        Assert.Null(snapshot);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_RejectsSvgFontRun()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120">
+              <defs>
+                <font id="DefaultFontFace" horiz-adv-x="100">
+                  <font-face font-family="DefaultFont" units-per-em="100" ascent="100" descent="0" />
+                  <glyph unicode="A" horiz-adv-x="100" d="M10 0H30V100H10Z" />
+                </font>
+              </defs>
+              <text id="label" x="10" y="60" font-family="DefaultFont" font-size="48">A</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings { EnableSvgFonts = true }));
 
         var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
 

--- a/tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs
+++ b/tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,18 +25,67 @@ public class SvgSceneTextCompilerTests
         binder: null,
         [typeof(SvgTextBase), typeof(string), typeof(SKRect), typeof(ISvgAssetLoader)],
         modifiers: null)!;
+    private static readonly MethodInfo s_measureTextAdvanceMethod = s_svgSceneTextCompilerType.GetMethod(
+        "MeasureTextAdvance",
+        BindingFlags.NonPublic | BindingFlags.Static,
+        binder: null,
+        [typeof(SvgTextBase), typeof(string), typeof(SKRect), typeof(ISvgAssetLoader)],
+        modifiers: null)!;
     private static readonly MethodInfo s_measureNaturalCodepointAdvancesMethod = s_svgSceneTextCompilerType.GetMethod(
         "MeasureNaturalCodepointAdvances",
         BindingFlags.NonPublic | BindingFlags.Static,
         binder: null,
         [typeof(SvgTextBase), typeof(IReadOnlyList<string>), typeof(SKRect), typeof(ISvgAssetLoader)],
         modifiers: null)!;
+    private static readonly MethodInfo s_tryPrepareFlatTextRunMethod = s_svgSceneTextCompilerType
+        .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+        .Single(method =>
+        {
+            if (method.Name != "TryPrepareFlatTextRun")
+            {
+                return false;
+            }
+
+            var parameters = method.GetParameters();
+            return parameters.Length == 5 &&
+                   parameters[0].ParameterType == typeof(SvgTextBase) &&
+                   parameters[1].ParameterType == typeof(string);
+        });
+    private static readonly MethodInfo s_tryPrepareSequentialTextRunsMethod = s_svgSceneTextCompilerType
+        .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+        .Single(method =>
+        {
+            if (method.Name != "TryPrepareSequentialTextRuns")
+            {
+                return false;
+            }
+
+            var parameters = method.GetParameters();
+            return parameters.Length == 5 &&
+                   parameters[0].ParameterType == typeof(SvgTextBase);
+        });
     private static readonly MethodInfo s_tryCompileSequentialTextMethod = s_svgSceneTextCompilerType.GetMethod(
         "TryCompileSequentialText",
         BindingFlags.NonPublic | BindingFlags.Static,
         binder: null,
         [typeof(SvgTextBase), typeof(SKRect), typeof(DrawAttributes), typeof(ISvgAssetLoader), typeof(SKRect).MakeByRefType(), typeof(SKPicture).MakeByRefType()],
         modifiers: null)!;
+
+    private sealed record PreparedSequentialRunSnapshot(
+        SvgTextBase StyleSource,
+        string Text,
+        float Advance);
+
+    private sealed record PreparedFlatTextRunSnapshot(
+        SvgTextBase StyleSource,
+        string Text,
+        float Advance,
+        float NaturalAdvance,
+        IReadOnlyList<float> NaturalCodepointAdvances);
+
+    private sealed record PreparedSequentialTextSnapshot(
+        float TotalAdvance,
+        IReadOnlyList<PreparedSequentialRunSnapshot> Runs);
 
     [Fact]
     public void MeasureNaturalCodepointAdvances_SimpleAsciiText_MatchesPrefixMeasurement()
@@ -142,6 +192,108 @@ public class SvgSceneTextCompilerTests
         Assert.Empty(compiledIds);
     }
 
+    [Fact]
+    public void TryPrepareFlatTextRun_ReturnsPreparedNaturalMetrics_ForSimpleText()
+    {
+        var document = CreateDocument("AVATAR ", 24);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+        var codepoints = InvokeSplitCodepoints("AVATAR ");
+
+        var prepared = InvokeTryPrepareFlatTextRun(svgText, "AVATAR ", geometryBounds, assetLoader, out var snapshot);
+
+        Assert.True(prepared);
+        Assert.NotNull(snapshot);
+        Assert.Same(svgText, snapshot!.StyleSource);
+        Assert.Equal("AVATAR ", snapshot.Text);
+        Assert.Equal(InvokeMeasureTextAdvance(svgText, "AVATAR ", geometryBounds, assetLoader), snapshot.Advance, 3);
+        Assert.Equal(InvokeMeasureNaturalTextAdvance(svgText, "AVATAR ", geometryBounds, assetLoader), snapshot.NaturalAdvance, 3);
+
+        var expectedCodepointAdvances = InvokeMeasureNaturalCodepointAdvances(svgText, codepoints, geometryBounds, assetLoader);
+        Assert.Equal(expectedCodepointAdvances.Length, snapshot.NaturalCodepointAdvances.Count);
+        for (var i = 0; i < expectedCodepointAdvances.Length; i++)
+        {
+            Assert.Equal(expectedCodepointAdvances[i], snapshot.NaturalCodepointAdvances[i], 3);
+        }
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_ReturnsPerRunAdvances_ForFlatNestedText()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">start<tspan font-weight="bold">Mid</tspan>end</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.True(prepared);
+        Assert.NotNull(snapshot);
+        Assert.Collection(
+            snapshot!.Runs,
+            run => Assert.Equal("start", run.Text),
+            run => Assert.Equal("Mid", run.Text),
+            run => Assert.Equal("end", run.Text));
+
+        foreach (var run in snapshot.Runs)
+        {
+            var expectedAdvance = InvokeMeasureTextAdvance(run.StyleSource, run.Text, geometryBounds, assetLoader);
+            Assert.Equal(expectedAdvance, run.Advance, 3);
+        }
+
+        Assert.Equal(snapshot.Runs.Sum(static run => run.Advance), snapshot.TotalAdvance, 3);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_RejectsPositionedTspanBarrier()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="240" height="80" viewBox="0 0 240 80">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">a<tspan dx="10">b</tspan>c</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.False(prepared);
+        Assert.Null(snapshot);
+    }
+
+    [Fact]
+    public void TryPrepareSequentialTextRuns_DoesNotRequirePrefixMeasurements()
+    {
+        var document = SvgDocumentCompatibilityLoader.FromSvg<SvgDocument>(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" width="320" height="120" viewBox="0 0 320 120">
+              <text id="label" x="10" y="40" font-family="sans-serif" font-size="24">start<tspan font-weight="bold">Mid</tspan>end</text>
+            </svg>
+            """);
+        var svgText = document.Descendants().OfType<SvgText>().Single(static element => element.ID == "label");
+        var geometryBounds = GetDocumentViewport(document);
+        var assetLoader = new StrictWholeRunAssetLoader(new Dictionary<string, float>(StringComparer.Ordinal)
+        {
+            ["start"] = 20f,
+            ["Mid"] = 12f,
+            ["end"] = 14f
+        });
+
+        var prepared = InvokeTryPrepareSequentialTextRuns(svgText, geometryBounds, assetLoader, trimLeadingWhitespaceAtStart: true, out var snapshot);
+
+        Assert.True(prepared);
+        Assert.NotNull(snapshot);
+        Assert.Equal(46f, snapshot!.TotalAdvance, 3);
+    }
+
     private static void VerifyMatchesPrefixMeasurement(string textContent)
     {
         var document = CreateDocument(textContent, 24);
@@ -238,6 +390,15 @@ public class SvgSceneTextCompilerTests
         return Assert.IsType<float>(s_measureNaturalTextAdvanceMethod.Invoke(null, [svgTextBase, text, geometryBounds, assetLoader]));
     }
 
+    private static float InvokeMeasureTextAdvance(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader)
+    {
+        return Assert.IsType<float>(s_measureTextAdvanceMethod.Invoke(null, [svgTextBase, text, geometryBounds, assetLoader]));
+    }
+
     private static float[] InvokeMeasureNaturalCodepointAdvances(
         SvgTextBase svgTextBase,
         IReadOnlyList<string> codepoints,
@@ -245,6 +406,45 @@ public class SvgSceneTextCompilerTests
         ISvgAssetLoader assetLoader)
     {
         return Assert.IsType<float[]>(s_measureNaturalCodepointAdvancesMethod.Invoke(null, [svgTextBase, codepoints, geometryBounds, assetLoader]));
+    }
+
+    private static bool InvokeTryPrepareFlatTextRun(
+        SvgTextBase svgTextBase,
+        string text,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader,
+        out PreparedFlatTextRunSnapshot? snapshot)
+    {
+        var args = new object?[]
+        {
+            svgTextBase,
+            text,
+            geometryBounds,
+            assetLoader,
+            null
+        };
+
+        var prepared = Assert.IsType<bool>(s_tryPrepareFlatTextRunMethod.Invoke(null, args));
+        if (!prepared)
+        {
+            snapshot = null;
+            return false;
+        }
+
+        Assert.NotNull(args[4]);
+        var preparedText = args[4]!;
+        var preparedType = preparedText.GetType();
+        var naturalCodepointAdvances = Assert.IsAssignableFrom<IEnumerable>(preparedType.GetProperty("NaturalCodepointAdvances")!.GetValue(preparedText))
+            .Cast<object>()
+            .Select(static value => Assert.IsType<float>(value))
+            .ToArray();
+        snapshot = new PreparedFlatTextRunSnapshot(
+            Assert.IsAssignableFrom<SvgTextBase>(preparedType.GetProperty("StyleSource")!.GetValue(preparedText)),
+            Assert.IsType<string>(preparedType.GetProperty("Text")!.GetValue(preparedText)),
+            Assert.IsType<float>(preparedType.GetProperty("Advance")!.GetValue(preparedText)),
+            Assert.IsType<float>(preparedType.GetProperty("NaturalAdvance")!.GetValue(preparedText)),
+            naturalCodepointAdvances);
+        return true;
     }
 
     private static bool InvokeTryCompileSequentialText(
@@ -263,6 +463,51 @@ public class SvgSceneTextCompilerTests
         };
 
         return Assert.IsType<bool>(s_tryCompileSequentialTextMethod.Invoke(null, args));
+    }
+
+    private static bool InvokeTryPrepareSequentialTextRuns(
+        SvgTextBase svgTextBase,
+        SKRect geometryBounds,
+        ISvgAssetLoader assetLoader,
+        bool trimLeadingWhitespaceAtStart,
+        out PreparedSequentialTextSnapshot? snapshot)
+    {
+        var args = new object?[]
+        {
+            svgTextBase,
+            geometryBounds,
+            assetLoader,
+            trimLeadingWhitespaceAtStart,
+            null
+        };
+
+        var prepared = Assert.IsType<bool>(s_tryPrepareSequentialTextRunsMethod.Invoke(null, args));
+        if (!prepared)
+        {
+            snapshot = null;
+            return false;
+        }
+
+        Assert.NotNull(args[4]);
+        var preparedText = args[4]!;
+        var preparedType = preparedText.GetType();
+        var totalAdvance = Assert.IsType<float>(preparedType.GetProperty("TotalAdvance")!.GetValue(preparedText));
+        var runsValue = Assert.IsAssignableFrom<IEnumerable>(preparedType.GetProperty("Runs")!.GetValue(preparedText));
+        var runs = new List<PreparedSequentialRunSnapshot>();
+
+        foreach (var runValue in runsValue)
+        {
+            Assert.NotNull(runValue);
+            var run = runValue!;
+            var runType = run.GetType();
+            runs.Add(new PreparedSequentialRunSnapshot(
+                Assert.IsAssignableFrom<SvgTextBase>(runType.GetProperty("StyleSource")!.GetValue(run)),
+                Assert.IsType<string>(runType.GetProperty("Text")!.GetValue(run)),
+                Assert.IsType<float>(runType.GetProperty("Advance")!.GetValue(run))));
+        }
+
+        snapshot = new PreparedSequentialTextSnapshot(totalAdvance, runs);
+        return true;
     }
 
     private static SKRect GetDocumentViewport(SvgDocument document)
@@ -355,6 +600,56 @@ public class SvgSceneTextCompilerTests
         private float GetAdvance(string text)
         {
             return _measuredAdvances.TryGetValue(text, out var advance) ? advance : 0f;
+        }
+    }
+
+    private sealed class StrictWholeRunAssetLoader : ISvgAssetLoader, ISvgTextRunTypefaceResolver
+    {
+        private readonly IReadOnlyDictionary<string, float> _measuredAdvances;
+        private readonly SKTypeface _typeface = SKTypeface.FromFamilyName(
+            "sans-serif",
+            SKFontStyleWeight.Normal,
+            SKFontStyleWidth.Normal,
+            SKFontStyleSlant.Upright);
+
+        public StrictWholeRunAssetLoader(IReadOnlyDictionary<string, float> measuredAdvances)
+        {
+            _measuredAdvances = measuredAdvances;
+        }
+
+        public bool EnableSvgFonts => false;
+
+        public SKImage LoadImage(Stream stream) => throw new NotSupportedException();
+
+        public List<TypefaceSpan> FindTypefaces(string? text, SKPaint paintPreferredTypeface)
+        {
+            var resolvedText = text ?? string.Empty;
+            return
+            [
+                new TypefaceSpan(resolvedText, GetAdvance(resolvedText), _typeface)
+            ];
+        }
+
+        public SKFontMetrics GetFontMetrics(SKPaint paint) => default;
+
+        public float MeasureText(string? text, SKPaint paint, ref SKRect bounds)
+        {
+            bounds = default;
+            return GetAdvance(text ?? string.Empty);
+        }
+
+        public SKPath? GetTextPath(string? text, SKPaint paint, float x, float y) => null;
+
+        public SKTypeface? FindRunTypeface(string? text, SKPaint paintPreferredTypeface) => _typeface;
+
+        private float GetAdvance(string text)
+        {
+            if (_measuredAdvances.TryGetValue(text, out var advance))
+            {
+                return advance;
+            }
+
+            throw new InvalidOperationException($"Unexpected prefix measurement for '{text}'.");
         }
     }
 }


### PR DESCRIPTION
# PR Summary: Prepare `Svg.Skia` Text Pipeline For Future Pretext Integration

## Overview

This change prepares `Svg.Skia` for a future `Pretext`-backed text preparation layer without introducing any runtime dependency on `Pretext` and without modifying upstream `PretextSharp`.

The refactor keeps SVG-specific placement and rendering ownership in `SvgSceneTextCompiler`, but extracts an internal prepared-text boundary that can eventually host a different preparation and measurement implementation.

## Why

The current text pipeline in `SvgSceneTextCompiler` mixes several concerns in the same area:

- flat text preparation
- repeated width measurement
- cached codepoint advance measurement
- sequential run aggregation
- SVG-specific placement and rendering

That coupling makes it hard to introduce a future prepared-text engine safely. The goal of this PR is to separate the preparation and measurement boundary first, while preserving the existing SVG behavior.

## What Changed

### 1. Added a prepared-text abstraction

A new internal partial file, `src/Svg.SceneGraph/SvgSceneTextCompiler.PreparedText.cs`, introduces:

- `ISvgPreparedTextEngine`
- `PreparedFlatTextRun`
- `PreparedSequentialText`
- `PreparedSequentialRun`
- `CurrentSvgPreparedTextEngine`

The default implementation still delegates to the current `Svg.Skia` text-measurement behavior. No `Pretext` APIs are referenced.

### 2. Moved flat-run preparation and cache ownership behind that abstraction

The prepared-text engine now owns the boundary for:

- full advance measurement
- natural width measurement
- natural codepoint advance measurement
- sequential run preparation
- local prepared-text cache clearing

The existing top-level helpers in `SvgSceneTextCompiler` now delegate to the prepared-text engine instead of owning the measurement policy directly.

### 3. Routed sequential fast paths through prepared sequential text

Sequential measurement and alignment paths now use prepared sequential text when they need aggregate run advances:

- sequential clip-path generation
- sequential draw path for non-left alignment
- sequential measurement path
- sequential total-advance helper

This keeps behavior unchanged while reducing duplication around repeated sequential width probes.

### 4. Preserved existing fast-path behavior

During review, the refactor was tightened to avoid unintended slowdowns or fallback regressions:

- left-aligned sequential draw still avoids unnecessary prepared-text work
- sequential preparation no longer computes natural codepoint advances for every run
- `MeasureSequentialTextRuns(...)` now falls back to summing per-run advances instead of returning `0` if preparation fails

## Tests Added

`tests/Svg.Skia.UnitTests/SvgSceneTextCompilerTests.cs` now includes coverage for:

- flat-run preparation returning the expected advance, natural width, and codepoint advances
- sequential preparation returning per-run advances for flat nested text
- sequential preparation rejecting positioned `tspan` barriers
- a regression guard proving sequential preparation does not require prefix-based codepoint measurement

## Behavioral Scope

This PR is intentionally limited to preparation and measurement refactoring.

It does **not** change ownership of:

- `textPath`
- per-glyph `x/y/dx/dy`
- rotation handling
- vertical layout semantics
- `textLength` placement rules
- SVG font outline rendering
- final draw/shaping ownership

Those remain in the existing `Svg.Skia` text engine.

## Commit Breakdown

1. `0c7a8c4c3` `Add Pretext feasibility plan`
   - Adds the feasibility analysis and staged refactor plan.

2. `5b5200b92` `Extract prepared text engine`
   - Introduces the internal prepared-text abstraction.
   - Moves measurement/cache concerns behind the abstraction.
   - Routes sequential measurement/alignment through prepared sequential text.

3. `924e57639` `Add prepared text compiler tests`
   - Adds focused unit coverage for the new abstraction boundary and regression scenarios.

## Validation

The final state was verified with:

- `dotnet build Svg.Skia.slnx -c Release`
- `dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore --filter "FullyQualifiedName~SvgSceneTextCompilerTests"`
- `dotnet test Svg.Skia.slnx -c Release`

Observed final result:

- focused `SvgSceneTextCompilerTests`: `12` passed
- full `Svg.Skia.UnitTests`: `1628` passed, `593` skipped, `2221` total
- full solution test run: passed

## Risks / Follow-up

This PR improves the integration boundary, but it does not yet provide a drop-in alternative prepared-text engine. The next safe steps would be:

- add more targeted benchmarks around repeated measurement scenarios
- decide whether cache clearing should be wired into broader model-level cache lifecycle
- introduce an experimental alternative implementation only after external version and backend constraints are resolved

## Notes

- No upstream `PretextSharp` changes are required or included here.
- The existing dirty `externals/SVG` submodule state was left untouched.
