### PR TITLE
Add regression for filtered groups with transformed children

### DIFF
--- a/tests/Svg.Skia.UnitTests/SvgRetainedSceneGraphTests.cs
+++ b/tests/Svg.Skia.UnitTests/SvgRetainedSceneGraphTests.cs
@@ -1413,6 +1413,35 @@ public class SvgRetainedSceneGraphTests : SvgUnitTest
     }
 
     [Fact]
+    public void RetainedSceneGraph_RendersFilteredGroupWithTransformedChild()
+    {
+        using var svg = new SKSvg();
+        svg.FromSvg(FilteredTransformedChildGroupSvg);
+
+        var scene = svg.RetainedSceneGraph;
+        Assert.NotNull(scene);
+        Assert.True(scene!.TryGetNodeById("a", out var groupNode));
+        Assert.NotNull(groupNode);
+        Assert.Equal(125f, groupNode!.GeometryBounds.Left, 3);
+        Assert.Equal(125f, groupNode.GeometryBounds.Top, 3);
+        Assert.Equal(375f, groupNode.GeometryBounds.Right, 3);
+        Assert.Equal(375f, groupNode.GeometryBounds.Bottom, 3);
+        Assert.NotNull(groupNode.FilterClip);
+        Assert.Equal(100f, groupNode.FilterClip.Value.Left, 3);
+        Assert.Equal(100f, groupNode.FilterClip.Value.Top, 3);
+        Assert.Equal(400f, groupNode.FilterClip.Value.Right, 3);
+        Assert.Equal(400f, groupNode.FilterClip.Value.Bottom, 3);
+
+        Assert.NotNull(svg.Picture);
+        using var bitmap = ToBitmap(svg, svg.Picture!);
+
+        var centerPixel = bitmap.GetPixel(250, 250);
+        Assert.True(
+            centerPixel.Alpha > 200 && centerPixel.Red < 20 && centerPixel.Green < 20 && centerPixel.Blue < 20,
+            $"Expected transformed child inside filtered group to render at the center but was {centerPixel}.");
+    }
+
+    [Fact]
     public void CreateRetainedSceneGraphPicture_MatchesCurrentPicture_ForUseAndMarkerDocument()
     {
         using var svg = new SKSvg();
@@ -2041,6 +2070,19 @@ public class SvgRetainedSceneGraphTests : SvgUnitTest
             <rect x="8" y="42" width="56" height="6" fill="#0000ff" opacity="0.5" />
             <rect x="8" y="60" width="56" height="6" fill="#ffff00" opacity="0.5" />
           </g>
+        </svg>
+        """;
+
+    private const string FilteredTransformedChildGroupSvg = """
+        <svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+          <g id="a" filter="url(#f)">
+            <circle cx="0" cy="0" r="125" fill="black" transform="translate(250 250)" />
+          </g>
+          <defs>
+            <filter id="f">
+              <feOffset dx="0" dy="0" />
+            </filter>
+          </defs>
         </svg>
         """;
 


### PR DESCRIPTION
# PR Summary: Filtered Group With Transformed Child Regression

## Summary

Adds regression coverage for GitHub issue #464, where a group with a filter could clip away a transformed child if the group bounds used for the filter region did not account for the child's transform.

## Related Issue

Fixes/validates behavior for:

- https://github.com/wieslawsoltes/Svg.Skia/issues/464

## Changes

- Added a focused retained scene graph regression test using the minimal SVG from the issue.
- Verified that the filtered group's geometry bounds include the transformed circle:
  - left/top: `125`
  - right/bottom: `375`
- Verified that the default object-bounding-box filter clip is derived from those transformed group bounds:
  - left/top: `100`
  - right/bottom: `400`
- Verified that the transformed child actually renders at the center of the image instead of being clipped away.

## Implementation Notes

No renderer code change was required. The current retained scene graph path already folds direct child transforms into structural group bounds before filter payload resolution. This PR locks that behavior down with a regression test so future bounds/filter changes do not reintroduce the issue.

## Validation

Commands run locally:

```sh
dotnet format tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj --no-restore --include tests/Svg.Skia.UnitTests/SvgRetainedSceneGraphTests.cs
dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore -p:IsTestProject=true --filter "FullyQualifiedName~SvgRetainedSceneGraphTests.RetainedSceneGraph_RendersFilteredGroupWithTransformedChild" --logger "console;verbosity=normal"
dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore -p:IsTestProject=true --filter "FullyQualifiedName~SvgRetainedSceneGraphTests" --logger "console;verbosity=minimal"
dotnet build Svg.Skia.slnx -c Release --no-restore
git diff --check
```

Results:

- Focused regression test passed.
- `SvgRetainedSceneGraphTests` passed: 82 passed, 0 failed, 0 skipped.
- Solution build passed with pre-existing warnings and 0 errors.
- `git diff --check` reported no whitespace errors.
