### PR TITLE
Handle relative image hrefs without base URI

### DIFF
--- a/src/Svg.Model/Services/SvgService.cs
+++ b/src/Svg.Model/Services/SvgService.cs
@@ -488,6 +488,11 @@ public static class SvgService
                 return GetImageFromDataUri(uriString, svgOwnerElement, assetLoader);
             }
 
+            if (!uri.IsAbsoluteUri)
+            {
+                return default;
+            }
+
             return GetImageFromWeb(uri, assetLoader);
         }
         catch (Exception ex)

--- a/tests/Svg.Model.UnitTests/SvgServiceImageUriTests.cs
+++ b/tests/Svg.Model.UnitTests/SvgServiceImageUriTests.cs
@@ -1,0 +1,84 @@
+using System;
+using Svg;
+using Svg.Model.Services;
+using Xunit;
+
+namespace Svg.Model.UnitTests;
+
+public class SvgServiceImageUriTests
+{
+    [Fact]
+    public void GetImageUri_RelativeImageHrefWithoutBaseUri_RemainsRelative()
+    {
+        const string svg = """
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 width="32" height="32">
+              <image id="missing-image" width="99" height="108" xlink:href="6F03BD87.png" />
+            </svg>
+            """;
+
+        var document = SvgService.FromSvg(svg);
+        Assert.NotNull(document);
+
+        var image = Assert.IsType<SvgImage>(document!.GetElementById("missing-image"));
+
+        var uri = SvgService.GetImageUri(image.Href, image);
+
+        Assert.False(uri.IsAbsoluteUri);
+        Assert.Equal("6F03BD87.png", uri.OriginalString);
+    }
+
+    [Fact]
+    public void GetImage_RelativeImageHrefWithoutBaseUri_ReturnsNull()
+    {
+        const string svg = """
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 width="32" height="32">
+              <image id="missing-image" width="99" height="108" xlink:href="6F03BD87.png" />
+            </svg>
+            """;
+
+        var document = SvgService.FromSvg(svg);
+        Assert.NotNull(document);
+
+        var image = Assert.IsType<SvgImage>(document!.GetElementById("missing-image"));
+
+        var loadedImage = SvgService.GetImage(image.Href, image, new TestAssetLoader());
+
+        Assert.Null(loadedImage);
+    }
+
+    [Fact]
+    public void GetImageUri_DocumentOwnerWithoutBaseUri_RemainsRelative()
+    {
+        const string svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" />
+            """;
+
+        var document = SvgService.FromSvg(svg);
+        Assert.NotNull(document);
+
+        var uri = SvgService.GetImageUri("6F03BD87.png", document!);
+
+        Assert.False(uri.IsAbsoluteUri);
+        Assert.Equal("6F03BD87.png", uri.OriginalString);
+    }
+
+    [Fact]
+    public void GetImageUri_DocumentOwnerUsesDocumentBaseUri()
+    {
+        const string svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" />
+            """;
+
+        var document = SvgService.FromSvg(svg);
+        Assert.NotNull(document);
+        document!.BaseUri = new Uri("https://example.test/assets/source.svg");
+
+        var uri = SvgService.GetImageUri("6F03BD87.png", document);
+
+        Assert.Equal(new Uri("https://example.test/assets/6F03BD87.png"), uri);
+    }
+}

--- a/tests/Svg.Skia.UnitTests/SKSvgTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgTests.cs
@@ -188,4 +188,35 @@ public class SKSvgTests : SvgUnitTest
         Assert.Equal(120, image.Width);
         Assert.Equal(40, image.Height);
     }
+
+    [Fact]
+    public void Load_RelativeImageHrefWithoutBaseUri_SkipsMissingImage()
+    {
+        const string svgMarkup = """
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 width="32px" height="32px" viewBox="0 0 32 32">
+              <rect width="32" height="32" fill="#232B34" />
+              <g opacity="0.1">
+                <image width="99" height="108" xlink:href="6F03BD87.png"
+                       transform="matrix(1 0 0 1 -33.5 -44.6934)" />
+              </g>
+              <circle cx="16" cy="16" r="8" fill="#586871" />
+            </svg>
+            """;
+
+        var svg = new SKSvg();
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes(svgMarkup));
+        using var _ = svg.Load(input);
+        using var output = new MemoryStream();
+
+        Assert.True(svg.Save(output, SkiaSharp.SKColors.Transparent));
+
+        output.Position = 0;
+        using var image = Image.Load<Rgba32>(output);
+        Assert.Equal(32, image.Width);
+        Assert.Equal(32, image.Height);
+        Assert.Equal(new Rgba32(0x23, 0x2B, 0x34), image[0, 0]);
+        Assert.Equal(new Rgba32(0x58, 0x68, 0x71), image[16, 16]);
+    }
 }


### PR DESCRIPTION
# PR Summary: Handle Relative Image Hrefs Without a Base URI

## Overview

Fixes `SvgService.GetImageUri` / image loading behavior for SVG documents that contain a relative image reference, such as `xlink:href="6F03BD87.png"`, when the owning document has no `BaseUri`.

Previously, unresolved relative image URIs could flow into the external image loading path. In issue #472, this showed up as a null-base URI failure while trying to resolve a relative image reference. The intended behavior for this case is to gracefully skip the missing/unresolvable image and continue rendering the rest of the SVG.

## Changes

- Updated `SvgService.GetImage` so unresolved relative image URIs return `null` directly.
- Kept data URI handling unchanged.
- Kept absolute URI image loading unchanged.
- Added model-level regression coverage for:
  - Relative image hrefs without a document base URI.
  - `GetImage` returning `null` for unresolved relative image hrefs.
  - The document-owner overload preserving relative URI behavior when `BaseUri` is missing.
  - The document-owner overload resolving relative hrefs when `BaseUri` exists.
- Added SKSvg rendering regression coverage for an issue-shaped SVG that includes a missing relative `xlink:href`.
- Strengthened the rendering regression by checking output dimensions and representative rendered pixels, proving normal SVG content still renders after the missing image is skipped.

## Rationale

An SVG loaded from a stream or inline string may not have a usable `BaseUri`. In that case a relative external image reference cannot be resolved safely. Returning `null` from image loading matches the existing renderer behavior for unavailable images: the image node becomes non-renderable while the rest of the document continues through the render pipeline.

This avoids depending on exception handling from `WebRequest.Create` or URI construction for normal missing-resource control flow.

## Verification

Commands run during development:

```bash
git submodule update --init --recursive
dotnet restore Svg.Skia.slnx
dotnet format Svg.Skia.slnx --no-restore --include src/Svg.Model/Services/SvgService.cs tests/Svg.Model.UnitTests/SvgServiceImageUriTests.cs tests/Svg.Skia.UnitTests/SKSvgTests.cs
git diff --check
dotnet test tests/Svg.Model.UnitTests/Svg.Model.UnitTests.csproj -f net10.0 -c Release --no-restore /p:IsTestProject=true --filter "FullyQualifiedName~SvgServiceImageUriTests"
dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore /p:IsTestProject=true --filter "FullyQualifiedName~SKSvgTests.Load_RelativeImageHrefWithoutBaseUri_SkipsMissingImage"
dotnet build Svg.Skia.slnx -c Release --no-restore
```

Results:

- Model regression tests passed: 4 passed, 0 failed.
- SKSvg rendering regression passed: 1 passed, 0 failed.
- Release build passed with existing package advisory warnings.

## Notes

- The PR summary file itself is intentionally not committed.
- The branch contains two commits:
  - `Skip unresolved relative image loads`
  - `Cover missing relative image base URI`
