### PR TITLE
Preserve synthetic bold for regular-only font fallback

### DIFF
--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -51,6 +51,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
 
         var preferredTypeface = paintPreferredTypeface.Typeface;
         var weight = _skiaModel.ToSKFontStyleWeight(preferredTypeface?.FontWeight ?? ShimSkiaSharp.SKFontStyleWeight.Normal);
+        var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : weight;
         var width = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var slant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
         var preferredFamily = preferredTypeface?.FamilyName;
@@ -73,13 +74,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             ret.Add(new(currentTypefaceText, _skiaModel.GetTextAdvance(currentTypefaceText, runningPaint),
                 runningPaint.Typeface is null
                     ? null
-                    : ShimSkiaSharp.SKTypeface.FromFamilyName(
-                        runningPaint.Typeface.FamilyName,
-                        // SkiaSharp provides int properties here. Let's just assume our
-                        // ShimSkiaSharp defines the same values as SkiaSharp and convert directly
-                        (ShimSkiaSharp.SKFontStyleWeight)runningPaint.Typeface.FontWeight,
-                        (ShimSkiaSharp.SKFontStyleWidth)runningPaint.Typeface.FontWidth,
-                        (ShimSkiaSharp.SKFontStyleSlant)runningPaint.Typeface.FontSlant)
+                    : ToShimTypeface(runningPaint.Typeface, requestedWeight)
             ));
         }
 
@@ -131,7 +126,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
 
         EnsureTypefaceProviderCaches();
 
-        var codepoints = CollectDistinctRenderableCodepoints(text);
+        var codepoints = CollectDistinctRenderableCodepoints(text!);
         if (codepoints.Count == 0)
         {
             return paintPreferredTypeface.Typeface;
@@ -139,6 +134,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
 
         var preferredTypeface = paintPreferredTypeface.Typeface;
         var preferredWeight = _skiaModel.ToSKFontStyleWeight(preferredTypeface?.FontWeight ?? ShimSkiaSharp.SKFontStyleWeight.Normal);
+        var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : preferredWeight;
         var preferredWidth = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var preferredSlant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
         var preferredFamily = preferredTypeface?.FamilyName;
@@ -185,7 +181,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             var candidate = candidates[i];
             if (CanRenderAllCodepoints(candidate, codepoints))
             {
-                return ToShimTypeface(candidate);
+                return ToShimTypeface(candidate, requestedWeight);
             }
         }
 
@@ -564,15 +560,25 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         return true;
     }
 
-    private static ShimSkiaSharp.SKTypeface? ToShimTypeface(SkiaSharp.SKTypeface? typeface)
+    private static ShimSkiaSharp.SKTypeface? ToShimTypeface(
+        SkiaSharp.SKTypeface? typeface,
+        SkiaSharp.SKFontStyleWeight? requestedWeight)
     {
-        return typeface is null || typeface.Handle == IntPtr.Zero
-            ? null
-            : ShimSkiaSharp.SKTypeface.FromFamilyName(
-                typeface.FamilyName,
-                (ShimSkiaSharp.SKFontStyleWeight)typeface.FontWeight,
-                (ShimSkiaSharp.SKFontStyleWidth)typeface.FontWidth,
-                (ShimSkiaSharp.SKFontStyleSlant)typeface.FontSlant);
+        if (typeface is null || typeface.Handle == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        var resolvedWeight = (SkiaSharp.SKFontStyleWeight)typeface.FontWeight;
+        var shimWeight = requestedWeight is { } weight && resolvedWeight < weight
+            ? (ShimSkiaSharp.SKFontStyleWeight)weight
+            : (ShimSkiaSharp.SKFontStyleWeight)resolvedWeight;
+
+        return ShimSkiaSharp.SKTypeface.FromFamilyName(
+            typeface.FamilyName,
+            shimWeight,
+            (ShimSkiaSharp.SKFontStyleWidth)typeface.FontWidth,
+            (ShimSkiaSharp.SKFontStyleSlant)typeface.FontSlant);
     }
 
     private SkiaSharp.SKTypeface? GetProviderTypeface(

--- a/tests/Svg.Skia.UnitTests/Issue462Tests.cs
+++ b/tests/Svg.Skia.UnitTests/Issue462Tests.cs
@@ -1,0 +1,119 @@
+#pragma warning disable CS0618 // FakeBoldText is deprecated on SKPaint; shim keeps the legacy surface for compatibility
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ShimSkiaSharp;
+using Svg.Skia.TypefaceProviders;
+using Svg.Skia.UnitTests.Common;
+using Xunit;
+using NativeTypeface = SkiaSharp.SKTypeface;
+
+namespace Svg.Skia.UnitTests;
+
+public class Issue462Tests : SvgUnitTest
+{
+    [Fact]
+    public void FindTypefaces_PreservesRequestedBoldForRegularOnlyResolvedFace()
+    {
+        using var provider = new RegularOnlyTypefaceProvider(GetFontsPath("SourceSansPro-Regular.ttf"));
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var model = new SkiaModel(settings);
+        var assetLoader = new SkiaSvgAssetLoader(model);
+        var paint = CreateRequestedBoldPaint(provider.FamilyName);
+
+        var span = Assert.Single(assetLoader.FindTypefaces("Bold Text", paint));
+
+        Assert.NotNull(span.Typeface);
+        Assert.Equal(SKFontStyleWeight.Bold, span.Typeface!.FontWeight);
+        AssertUsesSyntheticBold(model, span.Typeface);
+    }
+
+    [Fact]
+    public void FindRunTypeface_PreservesRequestedBoldForRegularOnlyResolvedFace()
+    {
+        using var provider = new RegularOnlyTypefaceProvider(GetFontsPath("SourceSansPro-Regular.ttf"));
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var model = new SkiaModel(settings);
+        var assetLoader = new SkiaSvgAssetLoader(model);
+        var paint = CreateRequestedBoldPaint(provider.FamilyName);
+
+        var typeface = assetLoader.FindRunTypeface("Bold Text", paint);
+
+        Assert.NotNull(typeface);
+        Assert.Equal(SKFontStyleWeight.Bold, typeface!.FontWeight);
+        AssertUsesSyntheticBold(model, typeface);
+    }
+
+    private static SKPaint CreateRequestedBoldPaint(string familyName)
+    {
+        return new SKPaint
+        {
+            TextSize = 48f,
+            Typeface = SKTypeface.FromFamilyName(
+                familyName,
+                SKFontStyleWeight.Bold,
+                SKFontStyleWidth.Normal,
+                SKFontStyleSlant.Upright)
+        };
+    }
+
+    private static void AssertUsesSyntheticBold(SkiaModel model, SKTypeface typeface)
+    {
+        using var localPaint = model.ToSKPaint(new SKPaint
+        {
+            TextSize = 48f,
+            Typeface = typeface
+        });
+
+        Assert.NotNull(localPaint);
+        Assert.True(localPaint!.FakeBoldText);
+    }
+
+    private sealed class RegularOnlyTypefaceProvider : ITypefaceProvider, IDisposable
+    {
+        private readonly NativeTypeface _typeface;
+
+        public RegularOnlyTypefaceProvider(string path)
+        {
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException("Test font was not found.", path);
+            }
+
+            _typeface = NativeTypeface.FromFile(path);
+            FamilyName = _typeface.FamilyName;
+        }
+
+        public string FamilyName { get; }
+
+        public NativeTypeface? FromFamilyName(
+            string fontFamily,
+            SkiaSharp.SKFontStyleWeight fontWeight,
+            SkiaSharp.SKFontStyleWidth fontWidth,
+            SkiaSharp.SKFontStyleSlant fontStyle)
+        {
+            var requestedFamilies = fontFamily
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(static family => family.Trim().Trim('"', '\''));
+
+            return requestedFamilies.Contains(FamilyName, StringComparer.OrdinalIgnoreCase)
+                ? _typeface
+                : null;
+        }
+
+        public void Dispose()
+        {
+            _typeface.Dispose();
+        }
+    }
+}
+
+#pragma warning restore CS0618


### PR DESCRIPTION
# Preserve synthetic bold for regular-only font fallback

## Related Issue

Fixes https://github.com/wieslawsoltes/Svg.Skia/issues/462.

## Problem

SVG text with `font-weight="bold"` can render too light, and in the reported Fabric.js output it appeared clipped or visually incomplete, when the requested font family only has a regular face available. The reporter narrowed the case to Century BT fonts where no bold TTF is installed.

Svg.Skia already had synthetic bold support in `SkiaModel.ApplyTypefaceAdjustments`: when a shim `SKPaint` asks for a heavier typeface than Skia resolves, the native Skia paint enables `FakeBoldText`.

The issue was that `SkiaSvgAssetLoader.FindTypefaces` and `FindRunTypeface` converted the resolved native typeface back into the shim typeface using the resolved face weight. If Skia resolved a regular face for a requested bold font, the retained text command later carried only the regular weight. At render time `ApplyTypefaceAdjustments` no longer saw a heavier requested weight, so synthetic bold was not enabled.

## Changes

- Preserve the requested font weight when converting resolved native typefaces back to shim typefaces.
- Only preserve that requested weight when the original paint actually carried a requested typeface.
- Keep generic or no-typeface fallback behavior tied to the resolved typeface's real weight, so ordinary fallback does not become accidentally emboldened.
- Apply the same conversion behavior to both fallback paths:
  - `FindTypefaces`, used for per-span fallback.
  - `FindRunTypeface`, used for full-run browser-compatible text resolution.

## Tests

Added `Issue462Tests` covering regular-only font resolution with a requested bold shim typeface:

- `FindTypefaces_PreservesRequestedBoldForRegularOnlyResolvedFace`
- `FindRunTypeface_PreservesRequestedBoldForRegularOnlyResolvedFace`

The tests use the existing `SvgUnitTest.GetFontsPath` fixture helper with `SourceSansPro-Regular.ttf` and a custom regular-only typeface provider. They verify that the shim typeface keeps the requested bold weight and that native paint conversion enables `FakeBoldText`.

## Validation

Ran:

```bash
dotnet format Svg.Skia.slnx --no-restore --include src/Svg.Skia/SkiaSvgAssetLoader.cs tests/Svg.Skia.UnitTests/Issue462Tests.cs
dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore --filter "Issue405|Issue462"
dotnet build src/Svg.Skia/Svg.Skia.csproj -c Release --no-restore
git diff --check
```

Results:

- Focused Issue405 and Issue462 tests passed: 8 passed.
- `Svg.Skia.csproj` Release build passed with 0 warnings and 0 errors.
- Diff whitespace check passed.

## Notes

The full solution build was not used as the final validation boundary because this local checkout was missing restored assets for many unrelated projects and the local SDK environment lacks .NET Framework 4.6.1 reference assemblies. The changed project and focused regression coverage both pass.
