### PR TITLE
Support clipPath in Svg.Controls.Avalonia

### DIFF
--- a/src/Svg.Controls.Avalonia/AvaloniaModelExtensions.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaModelExtensions.cs
@@ -623,6 +623,38 @@ public static class AvaloniaModelExtensions
             return null;
         }
 
+        if (path.Commands.Count == 1)
+        {
+            switch (path.Commands[0])
+            {
+                case AddRectPathCommand addRectPathCommand:
+                    return new AM.RectangleGeometry(addRectPathCommand.Rect.ToRect());
+
+                case AddRoundRectPathCommand addRoundRectPathCommand:
+                    return new AM.RectangleGeometry(
+                        addRoundRectPathCommand.Rect.ToRect(),
+                        addRoundRectPathCommand.Rx,
+                        addRoundRectPathCommand.Ry);
+
+                case AddOvalPathCommand addOvalPathCommand:
+                    return new AM.EllipseGeometry(addOvalPathCommand.Rect.ToRect());
+
+                case AddCirclePathCommand addCirclePathCommand:
+                    {
+                        var radius = addCirclePathCommand.Radius;
+                        var rect = new A.Rect(
+                            addCirclePathCommand.X - radius,
+                            addCirclePathCommand.Y - radius,
+                            radius + radius,
+                            radius + radius);
+                        return new AM.EllipseGeometry(rect);
+                    }
+
+                case AddPolyPathCommand addPolyPathCommand:
+                    return addPolyPathCommand.Points?.ToGeometry(addPolyPathCommand.Close);
+            }
+        }
+
         var streamGeometry = new AM.StreamGeometry();
 
         using var streamGeometryContext = streamGeometry.Open();
@@ -722,7 +754,90 @@ public static class AvaloniaModelExtensions
 
     public static AM.Geometry? ToGeometry(this ClipPath clipPath, bool isFilled)
     {
-        // TODO: clipPath
-        return null;
+        var geometry = default(AM.Geometry);
+        var referencedGeometry = clipPath.Clip?.ToGeometry(isFilled);
+        var localGeometry = ToGeometry(clipPath.Clips, isFilled);
+
+        if (referencedGeometry is { } && localGeometry is { })
+        {
+            geometry = new AM.CombinedGeometry(AM.GeometryCombineMode.Intersect, referencedGeometry, localGeometry);
+        }
+        else
+        {
+            geometry = referencedGeometry ?? localGeometry;
+        }
+
+        return ApplyTransform(geometry, clipPath.Transform);
+    }
+
+    private static AM.Geometry? ToGeometry(IList<PathClip>? clips, bool isFilled)
+    {
+        if (clips is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var geometry = default(AM.Geometry);
+
+        foreach (var clip in clips)
+        {
+            var clipGeometry = clip.ToGeometry(isFilled);
+            if (clipGeometry is null)
+            {
+                continue;
+            }
+
+            geometry = geometry is null
+                ? clipGeometry
+                : new AM.CombinedGeometry(AM.GeometryCombineMode.Union, geometry, clipGeometry);
+        }
+
+        return geometry;
+    }
+
+    private static AM.Geometry? ToGeometry(this PathClip clip, bool isFilled)
+    {
+        var geometry = default(AM.Geometry);
+        var nestedGeometry = clip.Clip?.ToGeometry(isFilled);
+
+        if (clip.Path?.Commands is { Count: > 0 })
+        {
+            geometry = clip.Path.ToGeometry(isFilled);
+            if (geometry is { } && nestedGeometry is { })
+            {
+                geometry = new AM.CombinedGeometry(AM.GeometryCombineMode.Intersect, geometry, nestedGeometry);
+            }
+        }
+        else if (nestedGeometry is { })
+        {
+            geometry = nestedGeometry;
+        }
+        else if (clip.Path is { })
+        {
+            geometry = clip.Path.ToGeometry(isFilled);
+        }
+
+        return ApplyTransform(geometry, clip.Transform);
+    }
+
+    private static AM.Geometry? ApplyTransform(AM.Geometry? geometry, SKMatrix? transform)
+    {
+        if (geometry is null || transform is null || transform.Value.IsIdentity)
+        {
+            return geometry;
+        }
+
+        var matrixTransform = new AM.MatrixTransform(transform.Value.ToMatrix());
+        geometry.Transform = geometry.Transform is { } existingTransform
+            ? new AM.TransformGroup
+            {
+                Children =
+                {
+                    existingTransform,
+                    matrixTransform
+                }
+            }
+            : matrixTransform;
+        return geometry;
     }
 }

--- a/src/Svg.Controls.Avalonia/AvaloniaPicture.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaPicture.cs
@@ -122,7 +122,7 @@ public sealed class AvaloniaPicture : IDisposable
                 {
                     if (clipPathCanvasCommand.ClipPath is { })
                     {
-                        var path = clipPathCanvasCommand.ClipPath.ToGeometry(false);
+                        var path = clipPathCanvasCommand.ClipPath.ToGeometry(true);
                         if (path is { })
                         {
                             // TODO: clipPathCanvasCommand.Operation;

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
@@ -1,6 +1,8 @@
 using System.Linq;
+using Avalonia;
 using Avalonia.Headless.XUnit;
 using Avalonia.Svg;
+using Avalonia.Svg.Commands;
 using ShimSkiaSharp;
 using ShimSkiaSharp.Editing;
 using Xunit;
@@ -10,6 +12,16 @@ namespace Avalonia.Svg.UnitTests;
 public class SvgSourceTests
 {
     private const string SampleSvg = "<svg width=\"10\" height=\"10\"><rect x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"red\" /></svg>";
+    private const string ClipPathSvg = """
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <clipPath id="clip">
+              <rect width="10" height="10" />
+            </clipPath>
+          </defs>
+          <rect fill="#F00" width="24" height="24" rx="12" clip-path="url(#clip)" />
+        </svg>
+        """;
     private const string SvgFontGlyphSvg = """
         <svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
           <defs>
@@ -68,5 +80,19 @@ public class SvgSourceTests
         Assert.NotEmpty(source.Picture!.FindCommands<DrawPathCanvasCommand>());
         Assert.Empty(source.Picture.FindCommands<DrawTextCanvasCommand>());
         Assert.Empty(source.Picture.FindCommands<DrawTextBlobCanvasCommand>());
+    }
+
+    [AvaloniaFact]
+    public void Record_ConvertsClipPathToGeometryClip()
+    {
+        var source = SvgSource.LoadFromSvg(ClipPathSvg);
+
+        Assert.NotNull(source.Picture);
+        using var picture = AvaloniaPicture.Record(source.Picture!);
+        var geometryClip = Assert.Single(picture.Commands.OfType<GeometryClipDrawCommand>());
+
+        Assert.NotNull(geometryClip.Clip);
+        Assert.Equal(new Rect(0, 0, 10, 10), geometryClip.Clip.Bounds);
+        Assert.Contains(picture.Commands, command => command is RectangleDrawCommand);
     }
 }


### PR DESCRIPTION
# PR Summary: Fix Avalonia clip-path rendering

## Summary

Fixes `Svg.Controls.Avalonia` clip-path rendering for SVGs loaded through the pure Avalonia control path. Previously, Skia picture recording preserved `ClipPathCanvasCommand` entries, but the Avalonia conversion layer returned `null` for `ClipPath.ToGeometry`, so `clip-path="url(#...)"` was effectively ignored by the Avalonia drawing command recorder.

This change converts retained clip-path payloads into Avalonia geometries and records them as geometry clips, allowing clipped SVG content to render correctly in `Svg.Controls.Avalonia`.

## Issue

Addresses GitHub issue #438: `Svg.Controls.Avalonia` did not honor a simple SVG clip path:

```xml
<clipPath id="clip">
  <rect width="10" height="10" />
</clipPath>
<rect fill="#F00" width="24" height="24" rx="12" clip-path="url(#clip)" />
```

The reported behavior showed the rounded rectangle rendered without the expected 10x10 clip. The expected result is that only the clipped upper-left portion is visible.

## Implementation Details

- Implemented `ClipPath` to Avalonia `Geometry` conversion in `AvaloniaModelExtensions`.
- Added conversion for `PathClip` entries, including nested clips.
- Combined local clip entries with `GeometryCombineMode.Union`, matching SVG clip-path behavior where child clip shapes contribute to the clipping region.
- Combined referenced/nested clips with `GeometryCombineMode.Intersect`, preserving nested clip constraints.
- Preserved clip transforms and composed them with any existing geometry transforms.
- Extended `SKPath.ToGeometry` to handle compact single-command shape paths:
  - `AddRectPathCommand`
  - `AddRoundRectPathCommand`
  - `AddOvalPathCommand`
  - `AddCirclePathCommand`
  - `AddPolyPathCommand`
- Updated `AvaloniaPicture` clip recording to request filled geometry for clip paths.

## Tests

Added a regression test using the issue SVG sample:

- Loads the SVG through `SvgSource.LoadFromSvg`.
- Records the `SKPicture` into an `AvaloniaPicture`.
- Asserts that a `GeometryClipDrawCommand` is emitted.
- Asserts that the clip geometry bounds are `0,0,10,10`.
- Asserts that the clipped rectangle draw command is still recorded.

## Validation

Validated locally with:

```sh
dotnet build src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj -f net8.0 -c Release --no-restore
dotnet build src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj -f net10.0 -c Release --no-restore
dotnet test tests/Svg.Controls.Avalonia.UnitTests/Svg.Controls.Avalonia.UnitTests.csproj -f net10.0 -c Release --no-restore
```

The net10.0 package build passed cleanly. The net8.0 package build passed with existing warnings from dependency projects. The affected Avalonia unit-test project passed all 11 tests.

## Notes

The full solution build was not used as the final validation target because this checkout initially lacked restored assets and, before submodule initialization, could not compile `Svg.Custom`. After running `git submodule update --init --recursive` and restoring the affected test project, the targeted package and unit-test validation completed successfully.
