### PR TITLE
Cache shared platform typeface lookups

### DIFF
--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -354,11 +354,14 @@ public partial class SkiaModel
             return null;
         }
 
+        var weight = (SkiaSharp.SKFontStyleWeight)style.Weight;
+        var width = (SkiaSharp.SKFontStyleWidth)style.Width;
+        var slant = (SkiaSharp.SKFontStyleSlant)style.Slant;
         var cacheKey = new TypefaceKey(
             candidate,
-            (SkiaSharp.SKFontStyleWeight)style.Weight,
-            (SkiaSharp.SKFontStyleWidth)style.Width,
-            (SkiaSharp.SKFontStyleSlant)style.Slant);
+            weight,
+            width,
+            slant);
         if (_resolvedTypefaceCache.TryGetValue(cacheKey, out var cached))
         {
             if (cached is not null && cached.Handle != IntPtr.Zero)
@@ -367,6 +370,17 @@ public partial class SkiaModel
             }
 
             _resolvedTypefaceCache.TryRemove(cacheKey, out _);
+        }
+
+        if (SharedTypefaceCache.TryGetResolvedTypeface(candidate, weight, width, slant, out var sharedCached))
+        {
+            if (sharedCached is not null)
+            {
+                _resolvedTypefaceCache.TryAdd(cacheKey, sharedCached);
+                TrimTypefaceCachesIfNeeded();
+            }
+
+            return sharedCached;
         }
 
         var fontManager = SkiaSharp.SKFontManager.Default;
@@ -406,7 +420,31 @@ public partial class SkiaModel
             _resolvedTypefaceCache.TryAdd(cacheKey, resolved);
             TrimTypefaceCachesIfNeeded();
         }
+
+        SharedTypefaceCache.AddResolvedTypeface(candidate, weight, width, slant, resolved);
         return resolved;
+    }
+
+    private static SkiaSharp.SKTypeface? ResolveProviderTypeface(
+        ITypefaceProvider typefaceProvider,
+        string candidate,
+        SkiaSharp.SKFontStyleWeight fontWeight,
+        SkiaSharp.SKFontStyleWidth fontWidth,
+        SkiaSharp.SKFontStyleSlant fontStyle)
+    {
+        var typeface = SharedTypefaceCache.TryGetOrAddProviderTypeface(
+            typefaceProvider,
+            candidate,
+            fontWeight,
+            fontWidth,
+            fontStyle,
+            out var cached)
+            ? cached
+            : typefaceProvider.FromFamilyName(candidate, fontWeight, fontWidth, fontStyle);
+
+        return typeface is { } && typeface.Handle == IntPtr.Zero
+            ? null
+            : typeface;
     }
 
     public SkiaSharp.SKTypeface? ToSKTypeface(SKTypeface? typeface)
@@ -437,7 +475,7 @@ public partial class SkiaModel
             {
                 foreach (var typefaceProvider in Settings.TypefaceProviders)
                 {
-                    var providerTypeface = typefaceProvider.FromFamilyName(candidate, fontWeight, fontWidth, fontStyle);
+                    var providerTypeface = ResolveProviderTypeface(typefaceProvider, candidate, fontWeight, fontWidth, fontStyle);
                     if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                     {
                         _typefaceCache.TryAdd(cacheKey, providerTypeface);
@@ -464,7 +502,7 @@ public partial class SkiaModel
                 {
                     foreach (var typefaceProvider in Settings.TypefaceProviders)
                     {
-                        var providerTypeface = typefaceProvider.FromFamilyName(candidate, fontWeight, fontWidth, fontStyle);
+                        var providerTypeface = ResolveProviderTypeface(typefaceProvider, candidate, fontWeight, fontWidth, fontStyle);
                         if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                         {
                             _typefaceCache.TryAdd(cacheKey, providerTypeface);
@@ -488,7 +526,7 @@ public partial class SkiaModel
         {
             foreach (var typefaceProvider in Settings.TypefaceProviders)
             {
-                var providerTypeface = typefaceProvider.FromFamilyName(SkiaSharp.SKTypeface.Default.FamilyName, fontWeight, fontWidth, fontStyle);
+                var providerTypeface = ResolveProviderTypeface(typefaceProvider, SkiaSharp.SKTypeface.Default.FamilyName, fontWeight, fontWidth, fontStyle);
                 if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                 {
                     _typefaceCache.TryAdd(cacheKey, providerTypeface);

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -405,7 +405,35 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         }
 
         var typeface = TryMatchCharacterFromCustomProviders(normalizedFamily, weight, width, slant, codepoint);
-        if (typeface is null && normalizedFamily is not null)
+        if (typeface is null)
+        {
+            if (!SharedTypefaceCache.TryGetMatchedCharacter(normalizedFamily, weight, width, slant, codepoint, out typeface))
+            {
+                typeface = MatchPlatformCharacter(normalizedFamily, weight, width, slant, codepoint);
+                SharedTypefaceCache.AddMatchedCharacter(normalizedFamily, weight, width, slant, codepoint, typeface);
+            }
+        }
+
+        if (typeface is { } && typeface.Handle == IntPtr.Zero)
+        {
+            typeface = null;
+        }
+
+        _matchCharacterCache.TryAdd(key, typeface);
+        TrimCachesIfNeeded();
+        return typeface;
+    }
+
+    private static SkiaSharp.SKTypeface? MatchPlatformCharacter(
+        string? normalizedFamily,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        int codepoint)
+    {
+        var typeface = default(SkiaSharp.SKTypeface);
+
+        if (normalizedFamily is not null)
         {
             foreach (var candidate in SkiaModel.EnumerateFontFamilyCandidates(normalizedFamily, browserCompatible: true))
             {
@@ -491,8 +519,6 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             typeface = null;
         }
 
-        _matchCharacterCache.TryAdd(key, typeface);
-        TrimCachesIfNeeded();
         return typeface;
     }
 
@@ -593,7 +619,9 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             _providerTypefaceCache.TryRemove(key, out _);
         }
 
-        var typeface = provider.FromFamilyName(familyName, weight, width, slant);
+        var typeface = SharedTypefaceCache.TryGetOrAddProviderTypeface(provider, familyName, weight, width, slant, out var sharedCached)
+            ? sharedCached
+            : provider.FromFamilyName(familyName, weight, width, slant);
         if (typeface is { } && typeface.Handle == IntPtr.Zero)
         {
             typeface = null;

--- a/src/Svg.Skia/TypefaceProviders/SharedTypefaceCache.cs
+++ b/src/Svg.Skia/TypefaceProviders/SharedTypefaceCache.cs
@@ -1,0 +1,322 @@
+// Copyright (c) Wieslaw Soltes. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Collections.Concurrent;
+
+namespace Svg.Skia.TypefaceProviders;
+
+internal static class SharedTypefaceCache
+{
+    private const int ProviderTypefaceCacheLimit = 1024;
+    private const int ResolvedTypefaceCacheLimit = 1024;
+    private const int MatchCharacterCacheLimit = 4096;
+
+    private enum ProviderKind
+    {
+        Default,
+        FontManager
+    }
+
+    private sealed class TypefaceCacheEntry
+    {
+        public TypefaceCacheEntry(SkiaSharp.SKTypeface? typeface)
+        {
+            Typeface = typeface;
+        }
+
+        public SkiaSharp.SKTypeface? Typeface { get; }
+    }
+
+    private readonly struct ProviderTypefaceKey : IEquatable<ProviderTypefaceKey>
+    {
+        public ProviderTypefaceKey(
+            ProviderKind providerKind,
+            IntPtr fontManagerHandle,
+            string familyName,
+            SkiaSharp.SKFontStyleWeight weight,
+            SkiaSharp.SKFontStyleWidth width,
+            SkiaSharp.SKFontStyleSlant slant)
+        {
+            ProviderKind = providerKind;
+            FontManagerHandle = fontManagerHandle;
+            FamilyName = familyName;
+            Weight = weight;
+            Width = width;
+            Slant = slant;
+        }
+
+        public ProviderKind ProviderKind { get; }
+        public IntPtr FontManagerHandle { get; }
+        public string FamilyName { get; }
+        public SkiaSharp.SKFontStyleWeight Weight { get; }
+        public SkiaSharp.SKFontStyleWidth Width { get; }
+        public SkiaSharp.SKFontStyleSlant Slant { get; }
+
+        public bool Equals(ProviderTypefaceKey other)
+        {
+            return ProviderKind == other.ProviderKind &&
+                   FontManagerHandle == other.FontManagerHandle &&
+                   string.Equals(FamilyName, other.FamilyName, StringComparison.Ordinal) &&
+                   Weight == other.Weight &&
+                   Width == other.Width &&
+                   Slant == other.Slant;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ProviderTypefaceKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = (int)ProviderKind;
+                hash = (hash * 397) ^ FontManagerHandle.GetHashCode();
+                hash = (hash * 397) ^ FamilyName.GetHashCode();
+                hash = (hash * 397) ^ (int)Weight;
+                hash = (hash * 397) ^ (int)Width;
+                hash = (hash * 397) ^ (int)Slant;
+                return hash;
+            }
+        }
+    }
+
+    private readonly struct ResolvedTypefaceKey : IEquatable<ResolvedTypefaceKey>
+    {
+        public ResolvedTypefaceKey(
+            string familyName,
+            SkiaSharp.SKFontStyleWeight weight,
+            SkiaSharp.SKFontStyleWidth width,
+            SkiaSharp.SKFontStyleSlant slant)
+        {
+            FamilyName = familyName;
+            Weight = weight;
+            Width = width;
+            Slant = slant;
+        }
+
+        public string FamilyName { get; }
+        public SkiaSharp.SKFontStyleWeight Weight { get; }
+        public SkiaSharp.SKFontStyleWidth Width { get; }
+        public SkiaSharp.SKFontStyleSlant Slant { get; }
+
+        public bool Equals(ResolvedTypefaceKey other)
+        {
+            return string.Equals(FamilyName, other.FamilyName, StringComparison.Ordinal) &&
+                   Weight == other.Weight &&
+                   Width == other.Width &&
+                   Slant == other.Slant;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ResolvedTypefaceKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = FamilyName.GetHashCode();
+                hash = (hash * 397) ^ (int)Weight;
+                hash = (hash * 397) ^ (int)Width;
+                hash = (hash * 397) ^ (int)Slant;
+                return hash;
+            }
+        }
+    }
+
+    private readonly struct MatchCharacterKey : IEquatable<MatchCharacterKey>
+    {
+        public MatchCharacterKey(
+            string? familyName,
+            SkiaSharp.SKFontStyleWeight weight,
+            SkiaSharp.SKFontStyleWidth width,
+            SkiaSharp.SKFontStyleSlant slant,
+            int codepoint)
+        {
+            FamilyName = familyName;
+            Weight = weight;
+            Width = width;
+            Slant = slant;
+            Codepoint = codepoint;
+        }
+
+        public string? FamilyName { get; }
+        public SkiaSharp.SKFontStyleWeight Weight { get; }
+        public SkiaSharp.SKFontStyleWidth Width { get; }
+        public SkiaSharp.SKFontStyleSlant Slant { get; }
+        public int Codepoint { get; }
+
+        public bool Equals(MatchCharacterKey other)
+        {
+            return string.Equals(FamilyName, other.FamilyName, StringComparison.Ordinal) &&
+                   Weight == other.Weight &&
+                   Width == other.Width &&
+                   Slant == other.Slant &&
+                   Codepoint == other.Codepoint;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MatchCharacterKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = FamilyName?.GetHashCode() ?? 0;
+                hash = (hash * 397) ^ (int)Weight;
+                hash = (hash * 397) ^ (int)Width;
+                hash = (hash * 397) ^ (int)Slant;
+                hash = (hash * 397) ^ Codepoint;
+                return hash;
+            }
+        }
+    }
+
+    private static readonly ConcurrentDictionary<ProviderTypefaceKey, TypefaceCacheEntry> s_providerTypefaceCache = new();
+    private static readonly ConcurrentDictionary<ResolvedTypefaceKey, TypefaceCacheEntry> s_resolvedTypefaceCache = new();
+    private static readonly ConcurrentDictionary<MatchCharacterKey, TypefaceCacheEntry> s_matchCharacterCache = new();
+
+    public static bool TryGetOrAddProviderTypeface(
+        ITypefaceProvider provider,
+        string familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        out SkiaSharp.SKTypeface? typeface)
+    {
+        if (!TryCreateProviderTypefaceKey(provider, familyName, weight, width, slant, out var key))
+        {
+            typeface = null;
+            return false;
+        }
+
+        if (TryGetValidTypeface(s_providerTypefaceCache, key, out typeface))
+        {
+            return true;
+        }
+
+        typeface = provider.FromFamilyName(familyName, weight, width, slant);
+        typeface = GetValidTypefaceOrNull(typeface);
+
+        s_providerTypefaceCache.TryAdd(key, new TypefaceCacheEntry(typeface));
+        TrimCacheIfNeeded(s_providerTypefaceCache, ProviderTypefaceCacheLimit);
+        return true;
+    }
+
+    public static bool TryGetResolvedTypeface(
+        string familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        out SkiaSharp.SKTypeface? typeface)
+    {
+        var key = new ResolvedTypefaceKey(familyName, weight, width, slant);
+        return TryGetValidTypeface(s_resolvedTypefaceCache, key, out typeface);
+    }
+
+    public static void AddResolvedTypeface(
+        string familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        SkiaSharp.SKTypeface? typeface)
+    {
+        var key = new ResolvedTypefaceKey(familyName, weight, width, slant);
+        s_resolvedTypefaceCache.TryAdd(key, new TypefaceCacheEntry(GetValidTypefaceOrNull(typeface)));
+        TrimCacheIfNeeded(s_resolvedTypefaceCache, ResolvedTypefaceCacheLimit);
+    }
+
+    public static bool TryGetMatchedCharacter(
+        string? familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        int codepoint,
+        out SkiaSharp.SKTypeface? typeface)
+    {
+        var key = new MatchCharacterKey(familyName, weight, width, slant, codepoint);
+        return TryGetValidTypeface(s_matchCharacterCache, key, out typeface);
+    }
+
+    public static void AddMatchedCharacter(
+        string? familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        int codepoint,
+        SkiaSharp.SKTypeface? typeface)
+    {
+        var key = new MatchCharacterKey(familyName, weight, width, slant, codepoint);
+        s_matchCharacterCache.TryAdd(key, new TypefaceCacheEntry(GetValidTypefaceOrNull(typeface)));
+        TrimCacheIfNeeded(s_matchCharacterCache, MatchCharacterCacheLimit);
+    }
+
+    private static bool TryCreateProviderTypefaceKey(
+        ITypefaceProvider provider,
+        string familyName,
+        SkiaSharp.SKFontStyleWeight weight,
+        SkiaSharp.SKFontStyleWidth width,
+        SkiaSharp.SKFontStyleSlant slant,
+        out ProviderTypefaceKey key)
+    {
+        switch (provider)
+        {
+            case DefaultTypefaceProvider:
+                key = new ProviderTypefaceKey(ProviderKind.Default, IntPtr.Zero, familyName, weight, width, slant);
+                return true;
+            case FontManagerTypefaceProvider fontManagerProvider:
+                var handle = fontManagerProvider.FontManager?.Handle ?? IntPtr.Zero;
+                key = new ProviderTypefaceKey(ProviderKind.FontManager, handle, familyName, weight, width, slant);
+                return handle != IntPtr.Zero;
+            default:
+                key = default;
+                return false;
+        }
+    }
+
+    private static SkiaSharp.SKTypeface? GetValidTypefaceOrNull(SkiaSharp.SKTypeface? typeface)
+    {
+        return typeface is { } && typeface.Handle == IntPtr.Zero
+            ? null
+            : typeface;
+    }
+
+    private static bool TryGetValidTypeface<TKey>(
+        ConcurrentDictionary<TKey, TypefaceCacheEntry> cache,
+        TKey key,
+        out SkiaSharp.SKTypeface? typeface)
+        where TKey : notnull
+    {
+        if (!cache.TryGetValue(key, out var cached))
+        {
+            typeface = null;
+            return false;
+        }
+
+        typeface = cached.Typeface;
+        if (typeface is null || typeface.Handle != IntPtr.Zero)
+        {
+            return true;
+        }
+
+        cache.TryRemove(key, out _);
+        typeface = null;
+        return false;
+    }
+
+    private static void TrimCacheIfNeeded<TKey>(
+        ConcurrentDictionary<TKey, TypefaceCacheEntry> cache,
+        int limit)
+        where TKey : notnull
+    {
+        if (cache.Count > limit)
+        {
+            cache.Clear();
+        }
+    }
+}

--- a/tests/Svg.Skia.UnitTests/SkiaSvgAssetLoaderCachingTests.cs
+++ b/tests/Svg.Skia.UnitTests/SkiaSvgAssetLoaderCachingTests.cs
@@ -1,9 +1,15 @@
 #pragma warning disable CS0618 // Shim paint keeps deprecated SKPaint text/typeface surface for compatibility
 
+using System.Collections.Generic;
 using System.Linq;
 using ShimSkiaSharp;
 using Svg.Skia;
+using Svg.Skia.TypefaceProviders;
 using Xunit;
+using NativeTypeface = SkiaSharp.SKTypeface;
+using NativeTypefaceSlant = SkiaSharp.SKFontStyleSlant;
+using NativeTypefaceWeight = SkiaSharp.SKFontStyleWeight;
+using NativeTypefaceWidth = SkiaSharp.SKFontStyleWidth;
 
 namespace Svg.Skia.UnitTests;
 
@@ -63,6 +69,33 @@ public class SkiaSvgAssetLoaderCachingTests
         Assert.True(mutatedAdvance > repeatedAdvance * 2f);
     }
 
+    [Fact]
+    public void SharedCaches_DoNotBypassCustomTypefaceProvidersAcrossModels()
+    {
+        var firstProvider = new CountingTypefaceProvider();
+        var secondProvider = new CountingTypefaceProvider();
+        var requestedTypeface = SKTypeface.FromFamilyName(
+            "Missing Custom Family",
+            SKFontStyleWeight.Normal,
+            SKFontStyleWidth.Normal,
+            SKFontStyleSlant.Upright);
+
+        var firstModel = new SkiaModel(new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { firstProvider }
+        });
+        var secondModel = new SkiaModel(new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { secondProvider }
+        });
+
+        firstModel.ToSKTypeface(requestedTypeface);
+        secondModel.ToSKTypeface(requestedTypeface);
+
+        Assert.True(firstProvider.CallCount > 0);
+        Assert.True(secondProvider.CallCount > 0);
+    }
+
     private static SKPaint CreateTextPaint(float textSize)
     {
         return new SKPaint
@@ -74,6 +107,21 @@ public class SkiaSvgAssetLoaderCachingTests
                 SKFontStyleWidth.Normal,
                 SKFontStyleSlant.Upright)
         };
+    }
+
+    private sealed class CountingTypefaceProvider : ITypefaceProvider
+    {
+        public int CallCount { get; private set; }
+
+        public NativeTypeface? FromFamilyName(
+            string fontFamily,
+            NativeTypefaceWeight fontWeight,
+            NativeTypefaceWidth fontWidth,
+            NativeTypefaceSlant fontStyle)
+        {
+            CallCount++;
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
# PR Summary: Improve repeated Linux font lookup performance

## Related Issue

Fixes #458.

## Problem

The issue reports a severe slowdown and apparent freezes when loading many SVG files through
`Skia.Controls.Avalonia` on Linux. The remaining investigation pointed at repeated font and
glyph fallback work, especially after the draw lock removal and clone/reload fixes had already
reduced other sources of contention.

The expensive paths are repeated across SVG loads:

- resolving a requested family/style through the default platform font manager
- asking the built-in typeface providers for the same family/style combinations
- matching a fallback typeface for individual codepoints during text run splitting

These lookups are platform-backed and can be especially expensive on Linux font stacks. The
existing instance-local caches help while one `SkiaModel`/`SkiaSvgAssetLoader` instance is reused,
but they do not help the control-like path that repeatedly constructs loader/model instances while
loading many SVGs.

## Changes

- Added `SharedTypefaceCache`, an internal bounded cache for platform and built-in typeface lookup
  results.
- Shared only safe, built-in lookup paths:
  - `DefaultTypefaceProvider`
  - `FontManagerTypefaceProvider`
  - `SKFontManager.Default` family/style resolution
  - `SKFontManager.Default.MatchCharacter` fallback results
- Kept custom providers instance-specific. Unknown `ITypefaceProvider` implementations bypass the
  shared cache and still run through the existing instance-local provider cache.
- Cached both positive and negative platform lookup results so repeated missing-family probes do not
  re-enter the native font manager for every SVG load.
- Normalized invalid native handles before storing or returning cached entries.
- Added a regression test proving shared caches do not bypass separate custom provider instances
  across separate `SkiaModel` instances.

## Commit Breakdown

1. `Add shared typeface cache`
   - Adds the internal cache helper and key types.
   - Includes cache size caps and invalid-handle checks.

2. `Reuse shared platform font caches`
   - Wires shared provider and resolved-family caches into `SkiaModel`.
   - Wires shared character fallback caching into `SkiaSvgAssetLoader`.
   - Extracts platform character matching so custom provider lookup stays first.

3. `Cover custom provider cache isolation`
   - Adds a focused unit test for custom provider isolation across model instances.

## Validation

- `dotnet format src/Svg.Skia/Svg.Skia.csproj --no-restore`
- `dotnet format tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj --no-restore`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-restore --no-build`
- `dotnet run --project tests/Svg.Skia.Benchmarks/Svg.Skia.Benchmarks.csproj -c Release --no-restore -- --profile-svg tests/Tests/HitTestText.svg 20`

Observed benchmark result for `tests/Tests/HitTestText.svg`:

- `Control-like source load`: mean `0.45 ms`
- `Compile retained scene (parsed doc)`: mean `0.36 ms`

Earlier baseline during investigation showed the same benchmark around:

- `Control-like source load`: mean `4.14 ms`
- `Compile retained scene (parsed doc)`: mean `2.46 ms`

## Notes And Risk

- The original issue sample archive linked from the GitHub discussion returned 404 during
  investigation, so validation used the repository benchmark harness and existing tests.
- Full solution build passes after restore. The build reports existing NuGet vulnerability warnings
  for packages such as `Tmds.DBus.Protocol`, `NuGet.Packaging`, and
  `System.Security.Cryptography.Xml`; these are unrelated to this font cache change.
- Shared caches are process-wide and bounded. When a cache exceeds its cap, it is cleared rather than
  growing without limit.
- The shared provider cache intentionally rejects custom provider types, because custom providers can
  carry mutable or instance-specific font state.
