### PR TITLE
Fix SVG C# codegen gradient output

### DIFF
--- a/src/ShimSkiaSharp/SKShader.cs
+++ b/src/ShimSkiaSharp/SKShader.cs
@@ -9,10 +9,10 @@ public abstract record SKShader : IDeepCloneable<SKShader>
     public static SKShader CreateColor(SKColor color, SKColorSpace colorSpace)
         => new ColorShader(color, colorSpace);
 
-    public static SKShader CreateLinearGradient(SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode)
+    public static SKShader CreateLinearGradient(SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode)
         => new LinearGradientShader(start, end, colors, colorSpace, colorPos, mode, null);
 
-    public static SKShader CreateLinearGradient(SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+    public static SKShader CreateLinearGradient(SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
         => new LinearGradientShader(start, end, colors, colorSpace, colorPos, mode, localMatrix);
 
     public static SKShader CreatePerlinNoiseFractalNoise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKPointI tileSize)
@@ -24,16 +24,16 @@ public abstract record SKShader : IDeepCloneable<SKShader>
     public static SKShader CreatePicture(SKPicture src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix, SKRect tile)
         => new PictureShader(src, tmx, tmy, localMatrix, tile);
 
-    public static SKShader CreateRadialGradient(SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode)
+    public static SKShader CreateRadialGradient(SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode)
         => new RadialGradientShader(center, radius, colors, colorSpace, colorPos, mode, null);
 
-    public static SKShader CreateRadialGradient(SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+    public static SKShader CreateRadialGradient(SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
         => new RadialGradientShader(center, radius, colors, colorSpace, colorPos, mode, localMatrix);
 
-    public static SKShader CreateTwoPointConicalGradient(SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode)
+    public static SKShader CreateTwoPointConicalGradient(SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode)
         => new TwoPointConicalGradientShader(start, startRadius, end, endRadius, colors, colorSpace, colorPos, mode, null);
 
-    public static SKShader CreateTwoPointConicalGradient(SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+    public static SKShader CreateTwoPointConicalGradient(SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorSpace, float[]? colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
         => new TwoPointConicalGradientShader(start, startRadius, end, endRadius, colors, colorSpace, colorPos, mode, localMatrix);
 
     public SKShader DeepClone() => DeepClone(new CloneContext());

--- a/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
+++ b/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
@@ -33,9 +33,17 @@ public static class SkiaCSharpModelExtensions
 
     public static string ToFloatString(this float value)
     {
-        if (float.IsNaN(value) || float.IsNegativeInfinity(value) || float.IsPositiveInfinity(value))
+        if (float.IsNaN(value))
         {
-            return string.Concat("float.", value.ToString(s_ci));
+            return "float.NaN";
+        }
+        if (float.IsNegativeInfinity(value))
+        {
+            return "float.NegativeInfinity";
+        }
+        if (float.IsPositiveInfinity(value))
+        {
+            return "float.PositiveInfinity";
         }
         return string.Concat(value.ToString(s_ci), "f");
     }
@@ -67,7 +75,7 @@ public static class SkiaCSharpModelExtensions
 
         for (int i = 0; i < array.Length; i++)
         {
-            sb.AppendFormat(s_ci, "{0:g}f, ", array[i]); // C# allows trailing , on end element
+            sb.Append(array[i].ToFloatString()).Append(", "); // C# allows trailing , on end element
         }
 
         sb.Append(" }");
@@ -81,12 +89,22 @@ public static class SkiaCSharpModelExtensions
 
         for (int i = 0; i < array.Length; i++)
         {
-            sb.AppendFormat(s_ci, "@\"{0}\", ", array[i]); // C# allows trailing , on end element
+            sb.AppendFormat(s_ci, "@\"{0}\", ", array[i].Replace("\"", "\"\"")); // C# allows trailing , on end element
         }
 
         sb.Append(" }");
 
         return sb;
+    }
+
+    private static string ToGradientColorPositions(float[]? array)
+    {
+        if (array is null || array.Any(static value => float.IsNaN(value) || float.IsNegativeInfinity(value) || float.IsPositiveInfinity(value)))
+        {
+            return "null";
+        }
+
+        return array.ToFloatArray().ToString();
     }
 
     public static string ToSKPoint(this SKPoint point)
@@ -434,12 +452,13 @@ public static class SkiaCSharpModelExtensions
                 }
             case LinearGradientShader linearGradientShader:
                 {
-                    if (linearGradientShader.Colors is null || linearGradientShader.ColorPos is null)
+                    if (linearGradientShader.Colors is null)
                     {
                         sb.AppendLine($"{indent}var {counter.ShaderVarName}{counterShader} = default(SKShader);");
                         return;
                     }
 
+                    var colorPos = ToGradientColorPositions(linearGradientShader.ColorPos);
                     if (linearGradientShader.LocalMatrix is { })
                     {
                         sb.Append($"{indent}var {counter.ShaderVarName}{counterShader} = ");
@@ -448,7 +467,7 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {linearGradientShader.End.ToSKPoint()},");
                         sb.AppendLine($"{indent}    {linearGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(linearGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {linearGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {linearGradientShader.Mode.ToSKShaderTileMode()},");
                         sb.AppendLine($"{indent}    {linearGradientShader.LocalMatrix.Value.ToSKMatrix()});");
                         return;
@@ -461,19 +480,20 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {linearGradientShader.End.ToSKPoint()},");
                         sb.AppendLine($"{indent}    {linearGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(linearGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {linearGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {linearGradientShader.Mode.ToSKShaderTileMode()});");
                         return;
                     }
                 }
             case RadialGradientShader radialGradientShader:
                 {
-                    if (radialGradientShader.Colors is null || radialGradientShader.ColorPos is null)
+                    if (radialGradientShader.Colors is null)
                     {
                         sb.AppendLine($"{indent}var {counter.ShaderVarName}{counterShader} = default(SKShader);");
                         return;
                     }
 
+                    var colorPos = ToGradientColorPositions(radialGradientShader.ColorPos);
                     if (radialGradientShader.LocalMatrix is { })
                     {
                         sb.Append($"{indent}var {counter.ShaderVarName}{counterShader} = ");
@@ -482,7 +502,7 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {radialGradientShader.Radius.ToFloatString()},");
                         sb.AppendLine($"{indent}    {radialGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(radialGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {radialGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {radialGradientShader.Mode.ToSKShaderTileMode()},");
                         sb.AppendLine($"{indent}    {radialGradientShader.LocalMatrix.Value.ToSKMatrix()});");
                         return;
@@ -495,19 +515,20 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {radialGradientShader.Radius.ToFloatString()},");
                         sb.AppendLine($"{indent}    {radialGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(radialGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {radialGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {radialGradientShader.Mode.ToSKShaderTileMode()});");
                         return;
                     }
                 }
             case TwoPointConicalGradientShader twoPointConicalGradientShader:
                 {
-                    if (twoPointConicalGradientShader.Colors is null || twoPointConicalGradientShader.ColorPos is null)
+                    if (twoPointConicalGradientShader.Colors is null)
                     {
                         sb.AppendLine($"{indent}var {counter.ShaderVarName}{counterShader} = default(SKShader);");
                         return;
                     }
 
+                    var colorPos = ToGradientColorPositions(twoPointConicalGradientShader.ColorPos);
                     if (twoPointConicalGradientShader.LocalMatrix is { })
                     {
                         sb.Append($"{indent}var {counter.ShaderVarName}{counterShader} = ");
@@ -518,7 +539,7 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.EndRadius.ToFloatString()},");
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {twoPointConicalGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.Mode.ToSKShaderTileMode()},");
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.LocalMatrix.Value.ToSKMatrix()});");
                         return;
@@ -533,7 +554,7 @@ public static class SkiaCSharpModelExtensions
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.EndRadius.ToFloatString()},");
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.Colors.ToSKColors()},");
                         sb.AppendLine($"{indent}    {(twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)},");
-                        sb.AppendLine($"{indent}    {twoPointConicalGradientShader.ColorPos.ToFloatArray()},");
+                        sb.AppendLine($"{indent}    {colorPos},");
                         sb.AppendLine($"{indent}    {twoPointConicalGradientShader.Mode.ToSKShaderTileMode()});");
                         return;
                     }

--- a/src/Svg.Model/Services/PaintingService.cs
+++ b/src/Svg.Model/Services/PaintingService.cs
@@ -134,10 +134,8 @@ internal static class PaintingService
                     {
                         stopColor = ToLinear(stopColor);
                     }
-                    var offset = svgGradientStop.Offset.ToDeviceValue(UnitRenderingType.Horizontal, svgGradientServer, skBounds);
-                    offset /= skBounds.Width;
                     colors.Add(stopColor);
-                    colorPos.Add(offset);
+                    colorPos.Add(GetGradientStopOffset(svgGradientStop));
                 }
             }
         }
@@ -181,6 +179,23 @@ internal static class PaintingService
                 colorPos[i] = maxPos;
             }
         }
+    }
+
+    private static float GetGradientStopOffset(SvgGradientStop svgGradientStop)
+    {
+        var offset = svgGradientStop.Offset;
+        var value = offset.Type == SvgUnitType.Percentage ? offset.Value / 100f : offset.Value;
+        if (float.IsNaN(value) || float.IsNegativeInfinity(value))
+        {
+            return 0f;
+        }
+
+        if (float.IsPositiveInfinity(value))
+        {
+            return 1f;
+        }
+
+        return Math.Min(Math.Max(value, 0f), 1f);
     }
 
     internal static SKColorF[] ToSkColorF(this SKColor[] skColors)

--- a/src/Svg.SceneGraph/SvgScenePaintingService.cs
+++ b/src/Svg.SceneGraph/SvgScenePaintingService.cs
@@ -466,10 +466,8 @@ internal static class SvgScenePaintingService
                     stopColor = ToLinear(stopColor);
                 }
 
-                var offset = svgGradientStop.Offset.ToDeviceValue(UnitRenderingType.Horizontal, svgReferencedGradientServer, skBounds);
-                offset /= skBounds.Width;
                 colors.Add(stopColor);
-                colorPos.Add(offset);
+                colorPos.Add(GetGradientStopOffset(svgGradientStop));
             }
         }
     }
@@ -489,6 +487,23 @@ internal static class SvgScenePaintingService
                 colorPos[i] = maxPos;
             }
         }
+    }
+
+    private static float GetGradientStopOffset(SvgGradientStop svgGradientStop)
+    {
+        var offset = svgGradientStop.Offset;
+        var value = offset.Type == SvgUnitType.Percentage ? offset.Value / 100f : offset.Value;
+        if (float.IsNaN(value) || float.IsNegativeInfinity(value))
+        {
+            return 0f;
+        }
+
+        if (float.IsPositiveInfinity(value))
+        {
+            return 1f;
+        }
+
+        return Math.Min(Math.Max(value, 0f), 1f);
     }
 
     private static SKColorF[] ToSkColorF(IReadOnlyList<SKColor> skColors)

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -565,6 +565,25 @@ public partial class SkiaModel
         };
     }
 
+    private static float[]? GetGradientColorPositions(float[]? colorPos)
+    {
+        if (colorPos is null)
+        {
+            return null;
+        }
+
+        for (var i = 0; i < colorPos.Length; i++)
+        {
+            var value = colorPos[i];
+            if (float.IsNaN(value) || float.IsNegativeInfinity(value) || float.IsPositiveInfinity(value))
+            {
+                return null;
+            }
+        }
+
+        return colorPos;
+    }
+
     public SkiaSharp.SKShader? ToSKShader(SKShader? shader)
     {
         switch (shader)
@@ -579,11 +598,12 @@ public partial class SkiaModel
                 }
             case LinearGradientShader linearGradientShader:
                 {
-                    if (linearGradientShader.Colors is null || linearGradientShader.ColorPos is null)
+                    if (linearGradientShader.Colors is null)
                     {
                         return null;
                     }
 
+                    var colorPos = GetGradientColorPositions(linearGradientShader.ColorPos);
                     if (linearGradientShader.LocalMatrix is { })
                     {
                         return SkiaSharp.SKShader.CreateLinearGradient(
@@ -593,7 +613,7 @@ public partial class SkiaModel
                             linearGradientShader.ColorSpace == SKColorSpace.Srgb
                                 ? Settings.Srgb
                                 : Settings.SrgbLinear,
-                            linearGradientShader.ColorPos,
+                            colorPos,
                             ToSKShaderTileMode(linearGradientShader.Mode),
                             ToSKMatrix(linearGradientShader.LocalMatrix.Value));
                     }
@@ -605,16 +625,17 @@ public partial class SkiaModel
                         linearGradientShader.ColorSpace == SKColorSpace.Srgb
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
-                        linearGradientShader.ColorPos,
+                        colorPos,
                         ToSKShaderTileMode(linearGradientShader.Mode));
                 }
             case RadialGradientShader radialGradientShader:
                 {
-                    if (radialGradientShader.Colors is null || radialGradientShader.ColorPos is null)
+                    if (radialGradientShader.Colors is null)
                     {
                         return null;
                     }
 
+                    var colorPos = GetGradientColorPositions(radialGradientShader.ColorPos);
                     if (radialGradientShader.LocalMatrix is { })
                     {
                         return SkiaSharp.SKShader.CreateRadialGradient(
@@ -624,7 +645,7 @@ public partial class SkiaModel
                             radialGradientShader.ColorSpace == SKColorSpace.Srgb
                                 ? Settings.Srgb
                                 : Settings.SrgbLinear,
-                            radialGradientShader.ColorPos,
+                            colorPos,
                             ToSKShaderTileMode(radialGradientShader.Mode),
                             ToSKMatrix(radialGradientShader.LocalMatrix.Value));
                     }
@@ -636,16 +657,17 @@ public partial class SkiaModel
                         radialGradientShader.ColorSpace == SKColorSpace.Srgb
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
-                        radialGradientShader.ColorPos,
+                        colorPos,
                         ToSKShaderTileMode(radialGradientShader.Mode));
                 }
             case TwoPointConicalGradientShader twoPointConicalGradientShader:
                 {
-                    if (twoPointConicalGradientShader.Colors is null || twoPointConicalGradientShader.ColorPos is null)
+                    if (twoPointConicalGradientShader.Colors is null)
                     {
                         return null;
                     }
 
+                    var colorPos = GetGradientColorPositions(twoPointConicalGradientShader.ColorPos);
                     if (twoPointConicalGradientShader.LocalMatrix is { })
                     {
                         return SkiaSharp.SKShader.CreateTwoPointConicalGradient(
@@ -657,7 +679,7 @@ public partial class SkiaModel
                             twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb
                                 ? Settings.Srgb
                                 : Settings.SrgbLinear,
-                            twoPointConicalGradientShader.ColorPos,
+                            colorPos,
                             ToSKShaderTileMode(twoPointConicalGradientShader.Mode),
                             ToSKMatrix(twoPointConicalGradientShader.LocalMatrix.Value));
                     }
@@ -671,7 +693,7 @@ public partial class SkiaModel
                         twoPointConicalGradientShader.ColorSpace == SKColorSpace.Srgb
                             ? Settings.Srgb
                             : Settings.SrgbLinear,
-                        twoPointConicalGradientShader.ColorPos,
+                        colorPos,
                         ToSKShaderTileMode(twoPointConicalGradientShader.Mode));
                 }
             case PictureShader pictureShader:

--- a/tests/Svg.Skia.UnitTests/SkiaCSharpCodeGenTests.cs
+++ b/tests/Svg.Skia.UnitTests/SkiaCSharpCodeGenTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using System.Linq;
+using ShimSkiaSharp;
+using Svg.CodeGen.Skia;
+using Svg.Model.Services;
+using Xunit;
+
+namespace Svg.Skia.UnitTests;
+
+public class SkiaCSharpCodeGenTests
+{
+    [Fact]
+    public void ToStringArray_EscapesVerbatimStringQuotes()
+    {
+        var code = new[] { "\"Black Ops One\"" }.ToStringArray().ToString();
+
+        Assert.Equal("new string[1] { @\"\"\"Black Ops One\"\"\",  }", code);
+    }
+
+    [Fact]
+    public void ToFloatArray_EmitsValidSpecialFloatConstants()
+    {
+        var code = new[] { float.NaN, float.PositiveInfinity, float.NegativeInfinity }.ToFloatArray().ToString();
+
+        Assert.Equal("new float[3] { float.NaN, float.PositiveInfinity, float.NegativeInfinity,  }", code);
+    }
+
+    [Fact]
+    public void Generate_UsesNullGradientPositionsWhenShaderContainsNonFiniteStops()
+    {
+        var paint = new SKPaint
+        {
+            Shader = SKShader.CreateRadialGradient(
+                new SKPoint(34.39571f, 97.36665f),
+                4.233333f,
+                new[]
+                {
+                    new SKColorF(0.3529412f, 0.3529412f, 0.3529412f, 1f),
+                    new SKColorF(0f, 0f, 0f, 0.9960785f)
+                },
+                SKColorSpace.Srgb,
+                new[] { float.NaN, float.NaN },
+                SKShaderTileMode.Clamp,
+                new SKMatrix
+                {
+                    ScaleX = 0.0007958741f,
+                    SkewX = 0.9999996f,
+                    TransX = -67.76066f,
+                    SkewY = -7.999998f,
+                    ScaleY = 1.9758927E-07f,
+                    TransY = 376.7656f,
+                    Persp2 = 1f
+                })
+        };
+        var path = new SKPath();
+        path.AddRect(SKRect.Create(0f, 0f, 10f, 10f));
+        var picture = new SKPicture(SKRect.Create(0f, 0f, 10f, 10f), new List<CanvasCommand>
+        {
+            new DrawPathCanvasCommand(path, paint)
+        });
+
+        var code = SkiaCSharpCodeGen.Generate(picture, "Svg", "Generated");
+
+        Assert.DoesNotContain("NaNf", code);
+        Assert.Contains("SKShader.CreateRadialGradient(", code);
+        Assert.Contains("    null,", code);
+    }
+
+    [Fact]
+    public void Generate_DoesNotEmitNaNGradientStopsForZeroWidthGradientBounds()
+    {
+        const string svgMarkup = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+              <defs>
+                <linearGradient id="g" gradientUnits="userSpaceOnUse">
+                  <stop offset="0%" stop-color="#666666" />
+                  <stop offset="100%" stop-color="#000000" />
+                </linearGradient>
+              </defs>
+              <line x1="50" y1="0" x2="50" y2="100" stroke="url(#g)" stroke-width="10" />
+            </svg>
+            """;
+        var document = SvgService.FromSvg(svgMarkup);
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+        var picture = SvgSceneRuntime.CreateModel(document, assetLoader);
+
+        Assert.NotNull(picture);
+        var shader = Assert.Single(EnumerateShaders(picture).OfType<LinearGradientShader>());
+        Assert.NotNull(shader.ColorPos);
+        Assert.Equal(0f, shader.ColorPos![0]);
+        Assert.Equal(1f, shader.ColorPos[1]);
+
+        var code = SkiaCSharpCodeGen.Generate(picture!, "Svg", "Generated");
+
+        Assert.DoesNotContain("NaN", code);
+    }
+
+    [Fact]
+    public void SkiaModel_ToSKShader_CreatesGradientsWithOptionalColorPositions()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var shaderModels = CreateGradientShaders(null)
+            .Concat(CreateGradientShaders(new[] { float.NaN, float.NaN }));
+
+        foreach (var shaderModel in shaderModels)
+        {
+            using var shader = model.ToSKShader(shaderModel);
+
+            Assert.NotNull(shader);
+        }
+    }
+
+    private static IEnumerable<SKShader> CreateGradientShaders(float[]? colorPos)
+    {
+        var colors = new[]
+        {
+            new SKColorF(1f, 0f, 0f, 1f),
+            new SKColorF(0f, 0f, 1f, 1f)
+        };
+
+        yield return new LinearGradientShader(
+            new SKPoint(0f, 0f),
+            new SKPoint(10f, 0f),
+            colors,
+            SKColorSpace.Srgb,
+            colorPos,
+            SKShaderTileMode.Clamp,
+            null);
+        yield return new RadialGradientShader(
+            new SKPoint(5f, 5f),
+            5f,
+            colors,
+            SKColorSpace.Srgb,
+            colorPos,
+            SKShaderTileMode.Clamp,
+            null);
+        yield return new TwoPointConicalGradientShader(
+            new SKPoint(2f, 2f),
+            1f,
+            new SKPoint(5f, 5f),
+            5f,
+            colors,
+            SKColorSpace.Srgb,
+            colorPos,
+            SKShaderTileMode.Clamp,
+            null);
+    }
+
+    private static IEnumerable<SKShader> EnumerateShaders(SKPicture? picture)
+    {
+        if (picture?.Commands is null)
+        {
+            yield break;
+        }
+
+        foreach (var command in picture.Commands)
+        {
+            switch (command)
+            {
+                case DrawPathCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case DrawTextBlobCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case DrawTextCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case DrawTextOnPathCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case DrawImageCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case SaveLayerCanvasCommand { Paint.Shader: { } shader }:
+                    yield return shader;
+                    break;
+                case DrawPictureCanvasCommand { Picture: { } nestedPicture }:
+                    foreach (var nestedShader in EnumerateShaders(nestedPicture))
+                    {
+                        yield return nestedShader;
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
+++ b/tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj
@@ -14,6 +14,7 @@
   <Import Project="..\..\build\SkiaSharp.Native.v3.props" />
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Svg.CodeGen.Skia\Svg.CodeGen.Skia.csproj" />
     <ProjectReference Include="..\..\src\Svg.Skia\Svg.Skia.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Fixes #460.

This PR fixes two SVG C# code generation failures reported in issue #460:

- generated font family arrays now escape embedded double quotes correctly for C# verbatim string literals
- generated gradient code no longer emits invalid float literals such as `NaNf`

It also fixes the renderer path that produced non-finite gradient stop positions for zero-width geometry bounds, so retained shader models are built with valid, clamped SVG stop offsets before code generation runs.

## Root Cause

The C# generator emitted verbatim strings with raw embedded quotes. For a font family such as `"Black Ops One"`, this produced invalid generated C# like `@""Black Ops One""` instead of doubling quotes inside the verbatim string.

Gradient color positions had two related problems:

- `ToFloatArray` appended `f` to every formatted float, which made non-finite values compile as invalid C# tokens such as `NaNf`.
- Gradient stop offsets were computed by converting the stop offset through `ToDeviceValue(...)` and dividing by `skBounds.Width`. For zero-width bounds, percentage stops could become `0 / 0`, producing `NaN` positions.

## Changes

- Emit valid C# constants for non-finite floats:
  - `float.NaN`
  - `float.PositiveInfinity`
  - `float.NegativeInfinity`
- Escape embedded quotes in generated verbatim string arrays.
- Generate `null` gradient color positions when retained shader positions are missing or non-finite, matching SkiaSharp's optional color-position behavior.
- Compute SVG gradient stop offsets directly from the stop offset value:
  - percentages are normalized to `0..1`
  - user values are treated as already normalized
  - non-finite and out-of-range values are clamped
- Align retained shader model and runtime Skia conversion behavior so `null` color positions remain valid instead of dropping the shader.
- Add regression tests for string escaping, special float literals, non-finite gradient positions, zero-width gradient bounds, and runtime conversion of optional gradient positions.

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore --filter "FullyQualifiedName~SkiaCSharpCodeGenTests" --logger "console;verbosity=normal"`
- `dotnet build Svg.Skia.slnx -c Release`
- `dotnet test Svg.Skia.slnx -c Release --no-restore`

Full solution tests passed. The main `Svg.Skia.UnitTests` run ended with 1,640 passed, 593 skipped, and 0 failed.
