### PR TITLE
Fix custom provider synthetic bold handling

### DIFF
--- a/src/Svg.Skia/SkiaModel.Caching.cs
+++ b/src/Svg.Skia/SkiaModel.Caching.cs
@@ -94,6 +94,18 @@ public partial class SkiaModel
         }
     }
 
+    private readonly struct TypefaceResolution
+    {
+        public TypefaceResolution(SkiaSharp.SKTypeface typeface, bool suppressSyntheticBold)
+        {
+            Typeface = typeface;
+            SuppressSyntheticBold = suppressSyntheticBold;
+        }
+
+        public SkiaSharp.SKTypeface Typeface { get; }
+        public bool SuppressSyntheticBold { get; }
+    }
+
     private readonly struct FontSignature : IEquatable<FontSignature>
     {
         public FontSignature(SkiaSharp.SKPaint paint)
@@ -243,7 +255,7 @@ public partial class SkiaModel
         public SkiaSharp.SKImageFilter ImageFilter { get; }
     }
 
-    private readonly ConcurrentDictionary<TypefaceKey, SkiaSharp.SKTypeface?> _typefaceCache = new();
+    private readonly ConcurrentDictionary<TypefaceKey, TypefaceResolution> _typefaceCache = new();
     private readonly ConcurrentDictionary<TypefaceKey, SkiaSharp.SKTypeface?> _resolvedTypefaceCache = new();
     private readonly object _positionedTextCacheLock = new();
     private readonly object _pictureCacheLock = new();
@@ -863,7 +875,8 @@ public partial class SkiaModel
         var strokeCap = ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = ToSKTextAlign(paint.TextAlign);
-        var typeface = ToSKTypeface(paint.Typeface);
+        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
+        var typeface = typefaceResolution.Typeface;
         var textEncoding = ToSKTextEncoding(paint.TextEncoding);
         var color = paint.Color is null
             ? SkiaSharp.SKColor.Empty
@@ -898,7 +911,7 @@ public partial class SkiaModel
             FilterQuality = filterQuality
         };
 
-        ApplyTypefaceAdjustments(paint, skPaint);
+        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution.SuppressSyntheticBold);
         return skPaint;
     }
 

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -411,6 +411,11 @@ public partial class SkiaModel
 
     public SkiaSharp.SKTypeface? ToSKTypeface(SKTypeface? typeface)
     {
+        return ResolveSKTypeface(typeface).Typeface;
+    }
+
+    private TypefaceResolution ResolveSKTypeface(SKTypeface? typeface)
+    {
         var fontFamily = typeface?.FamilyName;
         var fontWeight = ToSKFontStyleWeight(typeface?.FontWeight ?? SKFontStyleWeight.Normal);
         var fontWidth = ToSKFontStyleWidth(typeface?.FontWidth ?? SKFontStyleWidth.Normal);
@@ -422,7 +427,7 @@ public partial class SkiaModel
 
         if (_typefaceCache.TryGetValue(cacheKey, out var cached))
         {
-            if (cached is not null && cached.Handle != IntPtr.Zero)
+            if (cached.Typeface.Handle != IntPtr.Zero)
             {
                 return cached;
             }
@@ -440,9 +445,7 @@ public partial class SkiaModel
                     var providerTypeface = typefaceProvider.FromFamilyName(candidate, fontWeight, fontWidth, fontStyle);
                     if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                     {
-                        _typefaceCache.TryAdd(cacheKey, providerTypeface);
-                        TrimTypefaceCachesIfNeeded();
-                        return providerTypeface;
+                        return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider));
                     }
                 }
             }
@@ -450,9 +453,7 @@ public partial class SkiaModel
             var resolved = ResolveTypeface(candidate, style);
             if (resolved is { } && resolved.Handle != IntPtr.Zero)
             {
-                _typefaceCache.TryAdd(cacheKey, resolved);
-                TrimTypefaceCachesIfNeeded();
-                return resolved;
+                return CacheTypefaceResolution(cacheKey, resolved, suppressSyntheticBold: false);
             }
         }
 
@@ -467,9 +468,7 @@ public partial class SkiaModel
                         var providerTypeface = typefaceProvider.FromFamilyName(candidate, fontWeight, fontWidth, fontStyle);
                         if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                         {
-                            _typefaceCache.TryAdd(cacheKey, providerTypeface);
-                            TrimTypefaceCachesIfNeeded();
-                            return providerTypeface;
+                            return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider));
                         }
                     }
                 }
@@ -477,9 +476,7 @@ public partial class SkiaModel
                 var resolved = ResolveTypeface(candidate, style);
                 if (resolved is { } && resolved.Handle != IntPtr.Zero)
                 {
-                    _typefaceCache.TryAdd(cacheKey, resolved);
-                    TrimTypefaceCachesIfNeeded();
-                    return resolved;
+                    return CacheTypefaceResolution(cacheKey, resolved, suppressSyntheticBold: false);
                 }
             }
         }
@@ -491,9 +488,7 @@ public partial class SkiaModel
                 var providerTypeface = typefaceProvider.FromFamilyName(SkiaSharp.SKTypeface.Default.FamilyName, fontWeight, fontWidth, fontStyle);
                 if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                 {
-                    _typefaceCache.TryAdd(cacheKey, providerTypeface);
-                    TrimTypefaceCachesIfNeeded();
-                    return providerTypeface;
+                    return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider));
                 }
             }
         }
@@ -505,9 +500,20 @@ public partial class SkiaModel
         }
 
         var fallback = defaultTypeface ?? SkiaSharp.SKTypeface.Default;
-        _typefaceCache.TryAdd(cacheKey, fallback);
+        return CacheTypefaceResolution(cacheKey, fallback, suppressSyntheticBold: false);
+    }
+
+    private TypefaceResolution CacheTypefaceResolution(TypefaceKey cacheKey, SkiaSharp.SKTypeface typeface, bool suppressSyntheticBold)
+    {
+        var resolution = new TypefaceResolution(typeface, suppressSyntheticBold);
+        _typefaceCache.TryAdd(cacheKey, resolution);
         TrimTypefaceCachesIfNeeded();
-        return fallback;
+        return resolution;
+    }
+
+    private static bool ShouldSuppressSyntheticBold(ITypefaceProvider typefaceProvider)
+    {
+        return typefaceProvider is not FontManagerTypefaceProvider and not DefaultTypefaceProvider;
     }
 
     private static bool IsGenericFontFamilyName(string candidate)
@@ -1254,7 +1260,8 @@ public partial class SkiaModel
         var strokeCap = ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = ToSKTextAlign(paint.TextAlign);
-        var typeface = ToSKTypeface(paint.Typeface);
+        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
+        var typeface = typefaceResolution.Typeface;
         var textEncoding = ToSKTextEncoding(paint.TextEncoding);
         var color = paint.Color is null
             ? SkiaSharp.SKColor.Empty :
@@ -1289,13 +1296,18 @@ public partial class SkiaModel
             FilterQuality = filterQuality
         };
 
-        ApplyTypefaceAdjustments(paint, skPaint);
+        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution.SuppressSyntheticBold);
 
         return skPaint;
     }
 
-    private void ApplyTypefaceAdjustments(ShimSkiaSharp.SKPaint sourcePaint, SkiaSharp.SKPaint targetPaint)
+    private void ApplyTypefaceAdjustments(ShimSkiaSharp.SKPaint sourcePaint, SkiaSharp.SKPaint targetPaint, bool suppressSyntheticBold)
     {
+        if (suppressSyntheticBold)
+        {
+            return;
+        }
+
         if (sourcePaint.Typeface is null || targetPaint.Typeface is null)
         {
             return;

--- a/tests/Svg.Skia.UnitTests/Issue429Tests.cs
+++ b/tests/Svg.Skia.UnitTests/Issue429Tests.cs
@@ -1,0 +1,69 @@
+#pragma warning disable CS0618 // Typeface and FakeBoldText are deprecated on SKPaint; shim keeps the legacy surface for compatibility
+
+using System;
+using System.Collections.Generic;
+using ShimSkiaSharp;
+using Svg.Skia.TypefaceProviders;
+using Svg.Skia.UnitTests.Common;
+using Xunit;
+
+namespace Svg.Skia.UnitTests;
+
+public class Issue429Tests : SvgUnitTest
+{
+    [Fact]
+    public void CustomProviderTypefaceDoesNotTriggerSyntheticBold()
+    {
+        using var suppliedTypeface = SkiaSharp.SKTypeface.FromFile(GetFontsPath("NotoSans-Regular.ttf"));
+        Assert.NotNull(suppliedTypeface);
+
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider>
+            {
+                new AliasTypefaceProvider("Issue429-Regular", suppliedTypeface!)
+            }
+        };
+        var model = new SkiaModel(settings);
+        var paint = new SKPaint
+        {
+            Typeface = SKTypeface.FromFamilyName(
+                "Issue429-Regular",
+                SKFontStyleWeight.ExtraBlack,
+                SKFontStyleWidth.Normal,
+                SKFontStyleSlant.Upright)
+        };
+
+        using var skPaint = model.ToSKPaint(paint);
+
+        Assert.NotNull(skPaint);
+        Assert.Equal(suppliedTypeface!.Handle, skPaint!.Typeface?.Handle);
+        Assert.True(skPaint.Typeface!.FontWeight < (int)SkiaSharp.SKFontStyleWeight.ExtraBlack);
+        Assert.False(skPaint.FakeBoldText);
+    }
+
+    private sealed class AliasTypefaceProvider : ITypefaceProvider
+    {
+        private readonly string _familyName;
+        private readonly SkiaSharp.SKTypeface _typeface;
+
+        public AliasTypefaceProvider(string familyName, SkiaSharp.SKTypeface typeface)
+        {
+            _familyName = familyName;
+            _typeface = typeface;
+        }
+
+        public SkiaSharp.SKTypeface? FromFamilyName(
+            string fontFamily,
+            SkiaSharp.SKFontStyleWeight fontWeight,
+            SkiaSharp.SKFontStyleWidth fontWidth,
+            SkiaSharp.SKFontStyleSlant fontStyle)
+        {
+            return string.Equals(fontFamily, _familyName, StringComparison.Ordinal)
+                ? _typeface
+                : null;
+        }
+    }
+}
+
+#pragma warning restore CS0618


### PR DESCRIPTION
# Fix Issue 429: Custom Provider Synthetic Bold Handling

## Summary

This change fixes platform-dependent bold rendering when consumers provide custom fonts through `ITypefaceProvider`.
For custom providers, Svg.Skia now treats the returned `SKTypeface` as authoritative and does not apply synthetic bold based on the native typeface weight reported by Skia.

The fix addresses issue #429, where an SVG using custom regular and bold Roboto aliases rendered with a much larger bold/regular difference on Windows than on macOS after the synthetic bold handling introduced for generic font fallback.

## Root Cause

`SkiaModel.ApplyTypefaceAdjustments` compared the requested shim font weight with the resolved native `SKTypeface.FontWeight`.
If the native typeface reported a lower weight than requested, it enabled `SKPaint.FakeBoldText`.

That behavior is useful for default and generic family fallback, where Skia may resolve a regular face for a requested bold style.
However, it is not safe for custom providers:

- A custom provider may deliberately map an alias to a specific font file or already-selected face.
- The returned typeface is the application author's chosen result.
- Native `SKTypeface.FontWeight` metadata for loaded/custom fonts can vary by platform.

As a result, Windows could report a lower native weight for the custom provider's returned face and then apply synthetic bold, while macOS did not.

## Changes

- Added a `TypefaceResolution` value that carries both the resolved native typeface and whether synthetic bold should be suppressed.
- Changed the typeface cache to store `TypefaceResolution` instead of only `SKTypeface`.
- Updated both normal paint conversion and reusable render paint creation to pass the suppression flag into `ApplyTypefaceAdjustments`.
- Suppressed synthetic bold for custom `ITypefaceProvider` implementations, including `CustomTypefaceProvider` and user-provided providers.
- Kept synthetic bold enabled for the built-in `FontManagerTypefaceProvider`, `DefaultTypefaceProvider`, and fallback resolution paths so issue #405 behavior is preserved.
- Added a regression test for issue #429 using a custom provider that returns a known repo test font while the requested style asks for a much heavier weight.

## Verification

The following checks passed:

- `dotnet format Svg.Skia.slnx --no-restore --include src/Svg.Skia/SkiaModel.cs src/Svg.Skia/SkiaModel.Caching.cs tests/Svg.Skia.UnitTests/Issue429Tests.cs`
- `dotnet test tests/Svg.Skia.UnitTests/Svg.Skia.UnitTests.csproj -f net10.0 -c Release --no-restore --filter "FullyQualifiedName~Issue429Tests|FullyQualifiedName~Issue405Tests"`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-restore`

The full build still reports existing package vulnerability warnings, but no build or test failures.

