### PR TITLE
Fix Android 16 KB HarfBuzzSharp assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added shared animation playback in `SKSvg`, including animation time control, invalidation events, layered redraw, throttling helpers, and native-composition scene extraction.
 * Added host animation backends for Avalonia and Uno, including resolved-backend diagnostics and Avalonia retained `NativeComposition` playback with fallback.
 * Added an animation benchmark harness in `tests/Svg.Skia.Benchmarks` and exposed animation/backend controls in `samples/TestApp`.
+* Updated HarfBuzzSharp dependencies to `8.3.1.3` so Android consumers restore native assets with 16 KB page-size support.
 
 ## 0.3.0
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,10 +28,10 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
-    <PackageVersion Include="HarfBuzzSharp" Version="7.3.0.3" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.3" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0.3" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="7.3.0.3" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />


### PR DESCRIPTION
# PR Summary: Fix Android 16 KB page-size HarfBuzzSharp assets

## Summary

This PR updates the HarfBuzzSharp dependency floor used by `Svg.Skia` from
`7.3.0.3` to `8.3.1.3`.

The change addresses issue #524, where Android consumers of `Svg.Skia` could
still restore `HarfBuzzSharp.NativeAssets.Android 7.3.0.3` by default. That
older native asset package ships Android shared libraries aligned for 4 KB
pages, which is incompatible with Android 16 KB page-size requirements.

## Changes

- Updated central package versions in `Directory.Packages.props`:
  - `HarfBuzzSharp`
  - `HarfBuzzSharp.NativeAssets.Linux`
  - `HarfBuzzSharp.NativeAssets.macOS`
  - `HarfBuzzSharp.NativeAssets.Win32`
- Added an Unreleased changelog entry documenting the HarfBuzzSharp update and
  Android 16 KB page-size support.

## Rationale

`Svg.Skia` directly references `HarfBuzzSharp`, and the HarfBuzzSharp package
itself declares target-specific native asset dependencies. With version
`8.3.1.3`, Android target frameworks resolve
`HarfBuzzSharp.NativeAssets.Android 8.3.1.3` transitively through the
HarfBuzzSharp package metadata.

Keeping the fix at the `HarfBuzzSharp` version floor avoids adding
`HarfBuzzSharp.NativeAssets.Android` as an unconditional direct dependency of
`Svg.Skia`, which would be broader than necessary for desktop and non-Android
consumers.

## Verification

- Confirmed `Svg.Controls.Skia.Maui` on `net10.0-android36.0` resolves:
  - `HarfBuzzSharp 8.3.1.3`
  - `HarfBuzzSharp.NativeAssets.Android 8.3.1.3`
- Confirmed the packed `Svg.Skia` nuspec emits HarfBuzzSharp dependencies at
  `8.3.1.3`.
- Confirmed the Android `8.3.1.3` native libraries use `LOAD` segment alignment
  `2**14`, while the old `7.3.0.3` package used `2**12`.
- Ran:
  - `dotnet format Svg.Skia.slnx --no-restore`
  - `dotnet build Svg.Skia.slnx -c Release`
  - `dotnet test Svg.Skia.slnx -c Release`

## Notes

The build and test runs passed. They still report pre-existing package advisory,
nullable, obsolete API, and configured skipped visual fixture warnings unrelated
to this change.
