### PR TITLE
Avoid eager font manager initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,40 @@ dotnet add package Svg.Skia
 Install-Package Svg.Skia
 ```
 
+#### Linux native assets
+
+Linux applications must also deploy the SkiaSharp native library that matches
+the target distribution. On Alpine Linux and other small container images,
+prefer `SkiaSharp.NativeAssets.Linux.NoDependencies` instead of
+`SkiaSharp.NativeAssets.Linux`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Svg.Skia" Version="..." />
+  <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="..." />
+</ItemGroup>
+```
+
+Do not reference both Linux native asset packages in the same application. If
+the application already references `SkiaSharp.NativeAssets.Linux`, replace that
+reference with `SkiaSharp.NativeAssets.Linux.NoDependencies` for Alpine-style
+deployments.
+
+The `NoDependencies` package contains a `libSkiaSharp.so` build that does not
+depend on third-party Linux libraries such as Fontconfig. This reduces native
+library assumptions in Alpine/musl and minimal container images. It still does
+not provide the operating system font configuration or fonts. Install
+`fontconfig` and at least one font package in the runtime image so text and SVG
+font fallback can work:
+
+```dockerfile
+RUN apk add --no-cache fontconfig ttf-dejavu
+```
+
+Add any other font packages required by the SVG content. When publishing
+RID-specific applications for Alpine Linux, use a musl RID such as
+`linux-musl-x64` or `linux-musl-arm64`.
+
 JavaScript support is opt-in:
 
 ```

--- a/src/Svg.Skia/SkiaModel.Caching.cs
+++ b/src/Svg.Skia/SkiaModel.Caching.cs
@@ -875,8 +875,8 @@ public partial class SkiaModel
         var strokeCap = ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = ToSKTextAlign(paint.TextAlign);
-        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
-        var typeface = typefaceResolution.Typeface;
+        var typefaceResolution = ResolvePaintTypeface(paint);
+        var typeface = typefaceResolution?.Typeface;
         var textEncoding = ToSKTextEncoding(paint.TextEncoding);
         var color = paint.Color is null
             ? SkiaSharp.SKColor.Empty
@@ -908,7 +908,7 @@ public partial class SkiaModel
             BlendMode = blendMode
         };
 
-        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution.SuppressSyntheticBold);
+        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution?.SuppressSyntheticBold ?? false);
         return skPaint;
     }
 

--- a/src/Svg.Skia/SkiaModel.TextShaping.cs
+++ b/src/Svg.Skia/SkiaModel.TextShaping.cs
@@ -108,7 +108,7 @@ public partial class SkiaModel
             return false;
         }
 
-        using var skPaint = ToSKPaint(paint);
+        using var skPaint = ToSKTextPaint(paint);
         if (skPaint is null || !TryShapeText(text!, 0f, 0f, skPaint, rightToLeft, out var result))
         {
             return false;

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -313,9 +313,10 @@ public partial class SkiaModel
                 {
                     hash = (hash * 397) ^ (custom.Typeface?.Handle.GetHashCode() ?? 0);
                 }
-                else if (provider is FontManagerTypefaceProvider fontManagerProvider)
+                else if (provider is FontManagerTypefaceProvider fontManagerProvider &&
+                         fontManagerProvider.TryGetFontManagerHandle(out var handle))
                 {
-                    hash = (hash * 397) ^ (fontManagerProvider.FontManager?.Handle.GetHashCode() ?? 0);
+                    hash = (hash * 397) ^ handle.GetHashCode();
                 }
             }
 

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -1512,12 +1512,18 @@ public partial class SkiaModel
 
     private bool ShouldEmboldenTypeface(SKTypeface? sourceTypeface, SkiaSharp.SKTypeface? targetTypeface, bool suppressSyntheticBold)
     {
-        if (suppressSyntheticBold || sourceTypeface is null || targetTypeface is null)
+        if (suppressSyntheticBold || sourceTypeface is null)
         {
             return false;
         }
 
         var desiredWeight = (int)ToSKFontStyleWeight(sourceTypeface.FontWeight);
+        if (targetTypeface is null)
+        {
+            return !HasExplicitTypeface(sourceTypeface) &&
+                   desiredWeight > (int)SkiaSharp.SKFontStyleWeight.Normal;
+        }
+
         return targetTypeface.FontWeight < desiredWeight;
     }
 

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -580,6 +580,21 @@ public partial class SkiaModel
         return ResolveExplicitTypeface(paint.Typeface);
     }
 
+    internal SkiaSharp.SKPaint? ToSKTextPaint(SKPaint? paint)
+    {
+        var skPaint = ToSKPaint(paint);
+        if (paint is null || skPaint is null)
+        {
+            return skPaint;
+        }
+
+        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
+        skPaint.Typeface = typefaceResolution.Typeface;
+        skPaint.FakeBoldText = false;
+        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution.SuppressSyntheticBold);
+        return skPaint;
+    }
+
     private TypefaceResolution CacheTypefaceResolution(TypefaceKey cacheKey, SkiaSharp.SKTypeface typeface, bool suppressSyntheticBold)
     {
         var resolution = new TypefaceResolution(typeface, suppressSyntheticBold);
@@ -1407,14 +1422,14 @@ public partial class SkiaModel
 
     public SkiaSharp.SKFont ToSKFont(SKPaint paint)
     {
-        var typefaceResolution = ResolveExplicitTypeface(paint.Typeface);
-        var skFont = new SkiaSharp.SKFont(typefaceResolution?.Typeface, paint.TextSize)
+        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
+        var skFont = new SkiaSharp.SKFont(typefaceResolution.Typeface, paint.TextSize)
         {
             Edging = ToSKFontEdging(paint),
             Subpixel = paint.SubpixelText
         };
 
-        ApplyTypefaceAdjustments(paint, skFont, typefaceResolution?.SuppressSyntheticBold ?? false);
+        ApplyTypefaceAdjustments(paint, skFont, typefaceResolution.SuppressSyntheticBold);
         return skFont;
     }
 
@@ -1425,15 +1440,15 @@ public partial class SkiaModel
             return null;
         }
 
-        var typefaceResolution = ResolveExplicitTypeface(font.Typeface);
-        var skFont = new SkiaSharp.SKFont(typefaceResolution?.Typeface, font.Size, font.ScaleX, font.SkewX)
+        var typefaceResolution = ResolveSKTypeface(font.Typeface);
+        var skFont = new SkiaSharp.SKFont(typefaceResolution.Typeface, font.Size, font.ScaleX, font.SkewX)
         {
             Edging = ToSKFontEdging(font.Edging),
             Subpixel = font.Subpixel,
             Embolden = font.Embolden
         };
 
-        ApplyTypefaceAdjustments(font, skFont, typefaceResolution?.SuppressSyntheticBold ?? false);
+        ApplyTypefaceAdjustments(font, skFont, typefaceResolution.SuppressSyntheticBold);
         return skFont;
     }
 
@@ -2065,7 +2080,7 @@ public partial class SkiaModel
                         var y = drawTextCanvasCommand.Y;
                         var paint = wireframe
                             ? ToWireframePaint(drawTextCanvasCommand.Paint)
-                            : GetRenderPaint(drawTextCanvasCommand.Paint);
+                            : ToSKTextPaint(drawTextCanvasCommand.Paint);
                         if (paint is null)
                         {
                             break;
@@ -2108,7 +2123,7 @@ public partial class SkiaModel
                         var vOffset = drawTextOnPathCanvasCommand.VOffset;
                         var paint = wireframe
                             ? ToWireframePaint(drawTextOnPathCanvasCommand.Paint)
-                            : GetRenderPaint(drawTextOnPathCanvasCommand.Paint);
+                            : ToSKTextPaint(drawTextOnPathCanvasCommand.Paint);
                         if (path is null || paint is null)
                         {
                             break;

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -565,10 +565,19 @@ public partial class SkiaModel
         return CacheTypefaceResolution(cacheKey, fallback, suppressSyntheticBold: false);
     }
 
+    internal static bool HasExplicitTypeface(SKTypeface? typeface)
+    {
+        return !string.IsNullOrWhiteSpace(typeface?.FamilyName);
+    }
+
+    private TypefaceResolution? ResolveExplicitTypeface(SKTypeface? typeface)
+    {
+        return HasExplicitTypeface(typeface) ? ResolveSKTypeface(typeface) : null;
+    }
+
     private TypefaceResolution? ResolvePaintTypeface(SKPaint paint)
     {
-        var typeface = paint.Typeface;
-        return typeface is null ? null : ResolveSKTypeface(typeface);
+        return ResolveExplicitTypeface(paint.Typeface);
     }
 
     private TypefaceResolution CacheTypefaceResolution(TypefaceKey cacheKey, SkiaSharp.SKTypeface typeface, bool suppressSyntheticBold)
@@ -1398,14 +1407,14 @@ public partial class SkiaModel
 
     public SkiaSharp.SKFont ToSKFont(SKPaint paint)
     {
-        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
-        var skFont = new SkiaSharp.SKFont(typefaceResolution.Typeface, paint.TextSize)
+        var typefaceResolution = ResolveExplicitTypeface(paint.Typeface);
+        var skFont = new SkiaSharp.SKFont(typefaceResolution?.Typeface, paint.TextSize)
         {
             Edging = ToSKFontEdging(paint),
             Subpixel = paint.SubpixelText
         };
 
-        ApplyTypefaceAdjustments(paint, skFont, typefaceResolution.SuppressSyntheticBold);
+        ApplyTypefaceAdjustments(paint, skFont, typefaceResolution?.SuppressSyntheticBold ?? false);
         return skFont;
     }
 
@@ -1416,15 +1425,15 @@ public partial class SkiaModel
             return null;
         }
 
-        var typefaceResolution = ResolveSKTypeface(font.Typeface);
-        var skFont = new SkiaSharp.SKFont(typefaceResolution.Typeface, font.Size, font.ScaleX, font.SkewX)
+        var typefaceResolution = ResolveExplicitTypeface(font.Typeface);
+        var skFont = new SkiaSharp.SKFont(typefaceResolution?.Typeface, font.Size, font.ScaleX, font.SkewX)
         {
             Edging = ToSKFontEdging(font.Edging),
             Subpixel = font.Subpixel,
             Embolden = font.Embolden
         };
 
-        ApplyTypefaceAdjustments(font, skFont, typefaceResolution.SuppressSyntheticBold);
+        ApplyTypefaceAdjustments(font, skFont, typefaceResolution?.SuppressSyntheticBold ?? false);
         return skFont;
     }
 
@@ -2178,7 +2187,7 @@ public partial class SkiaModel
         var strokeCap = paint is null ? SkiaSharp.SKStrokeCap.Butt : ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = paint is null ? SkiaSharp.SKStrokeJoin.Miter : ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = paint is null ? SkiaSharp.SKTextAlign.Left : ToSKTextAlign(paint.TextAlign);
-        var typeface = paint?.Typeface is null ? null : ToSKTypeface(paint.Typeface);
+        var typeface = paint is null ? null : ResolveExplicitTypeface(paint.Typeface)?.Typeface;
         var textEncoding = paint is null ? SkiaSharp.SKTextEncoding.Utf8 : ToSKTextEncoding(paint.TextEncoding);
         var colorFilter = paint is null ? null : ToSKColorFilter(paint.ColorFilter);
         var imageFilter = paint is null ? null : ToSKImageFilter(paint.ImageFilter);

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -565,6 +565,12 @@ public partial class SkiaModel
         return CacheTypefaceResolution(cacheKey, fallback, suppressSyntheticBold: false);
     }
 
+    private TypefaceResolution? ResolvePaintTypeface(SKPaint paint)
+    {
+        var typeface = paint.Typeface;
+        return typeface is null ? null : ResolveSKTypeface(typeface);
+    }
+
     private TypefaceResolution CacheTypefaceResolution(TypefaceKey cacheKey, SkiaSharp.SKTypeface typeface, bool suppressSyntheticBold)
     {
         var resolution = new TypefaceResolution(typeface, suppressSyntheticBold);
@@ -1433,8 +1439,8 @@ public partial class SkiaModel
         var strokeCap = ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = ToSKTextAlign(paint.TextAlign);
-        var typefaceResolution = ResolveSKTypeface(paint.Typeface);
-        var typeface = typefaceResolution.Typeface;
+        var typefaceResolution = ResolvePaintTypeface(paint);
+        var typeface = typefaceResolution?.Typeface;
         var textEncoding = ToSKTextEncoding(paint.TextEncoding);
         var color = paint.Color is null
             ? SkiaSharp.SKColor.Empty :
@@ -1466,7 +1472,7 @@ public partial class SkiaModel
             BlendMode = blendMode
         };
 
-        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution.SuppressSyntheticBold);
+        ApplyTypefaceAdjustments(paint, skPaint, typefaceResolution?.SuppressSyntheticBold ?? false);
 
         return skPaint;
     }
@@ -2172,7 +2178,7 @@ public partial class SkiaModel
         var strokeCap = paint is null ? SkiaSharp.SKStrokeCap.Butt : ToSKStrokeCap(paint.StrokeCap);
         var strokeJoin = paint is null ? SkiaSharp.SKStrokeJoin.Miter : ToSKStrokeJoin(paint.StrokeJoin);
         var textAlign = paint is null ? SkiaSharp.SKTextAlign.Left : ToSKTextAlign(paint.TextAlign);
-        var typeface = paint is null ? null : ToSKTypeface(paint.Typeface);
+        var typeface = paint?.Typeface is null ? null : ToSKTypeface(paint.Typeface);
         var textEncoding = paint is null ? SkiaSharp.SKTextEncoding.Utf8 : ToSKTextEncoding(paint.TextEncoding);
         var colorFilter = paint is null ? null : ToSKColorFilter(paint.ColorFilter);
         var imageFilter = paint is null ? null : ToSKImageFilter(paint.ImageFilter);

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -2078,7 +2078,7 @@ public partial class SkiaModel
                         var text = drawTextCanvasCommand.Text;
                         var x = drawTextCanvasCommand.X;
                         var y = drawTextCanvasCommand.Y;
-                        var paint = wireframe
+                        using var paint = wireframe
                             ? ToWireframePaint(drawTextCanvasCommand.Paint)
                             : ToSKTextPaint(drawTextCanvasCommand.Paint);
                         if (paint is null)
@@ -2121,7 +2121,7 @@ public partial class SkiaModel
                         var path = GetRenderPath(drawTextOnPathCanvasCommand.Path);
                         var hOffset = drawTextOnPathCanvasCommand.HOffset;
                         var vOffset = drawTextOnPathCanvasCommand.VOffset;
-                        var paint = wireframe
+                        using var paint = wireframe
                             ? ToWireframePaint(drawTextOnPathCanvasCommand.Paint)
                             : ToSKTextPaint(drawTextOnPathCanvasCommand.Paint);
                         if (path is null || paint is null)

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -167,7 +167,10 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         var spans = FindTypefaces(text, paintPreferredTypeface);
         for (var i = 0; i < spans.Count; i++)
         {
-            AddCandidate(_skiaModel.ToSKTypeface(spans[i].Typeface));
+            if (spans[i].Typeface is { } spanTypeface)
+            {
+                AddCandidate(_skiaModel.ToSKTypeface(spanTypeface));
+            }
         }
 
         for (var i = 0; i < codepoints.Count; i++)
@@ -402,7 +405,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         }
 
         var typeface = TryMatchCharacterFromCustomProviders(normalizedFamily, weight, width, slant, codepoint);
-        if (typeface is null)
+        if (typeface is null && ShouldUsePlatformCharacterFallback(normalizedFamily, codepoint))
         {
             if (!SharedTypefaceCache.TryGetMatchedCharacter(normalizedFamily, weight, width, slant, codepoint, out typeface))
             {
@@ -419,6 +422,30 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         _matchCharacterCache.TryAdd(key, typeface);
         TrimCachesIfNeeded();
         return typeface;
+    }
+
+    private bool ShouldUsePlatformCharacterFallback(string? familyName, int codepoint)
+    {
+        return familyName is not null || codepoint > 0x007F || HasNonPlatformTypefaceProviders();
+    }
+
+    private bool HasNonPlatformTypefaceProviders()
+    {
+        var providers = _skiaModel.Settings.TypefaceProviders;
+        if (providers is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < providers.Count; i++)
+        {
+            if (providers[i] is not FontManagerTypefaceProvider and not DefaultTypefaceProvider)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static SkiaSharp.SKTypeface? MatchPlatformCharacter(
@@ -657,6 +684,12 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         var familyKey = familyName ?? "Default";
         foreach (var provider in _skiaModel.Settings.TypefaceProviders)
         {
+            if (familyName is null &&
+                provider is FontManagerTypefaceProvider or DefaultTypefaceProvider)
+            {
+                continue;
+            }
+
             var typeface = GetProviderTypeface(provider, familyKey, weight, width, slant);
             if (typeface is { } && typeface.ContainsGlyph(codepoint))
             {

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -405,7 +405,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         }
 
         var typeface = TryMatchCharacterFromCustomProviders(normalizedFamily, weight, width, slant, codepoint);
-        if (typeface is null && ShouldUsePlatformCharacterFallback(normalizedFamily, codepoint))
+        if (typeface is null)
         {
             if (!SharedTypefaceCache.TryGetMatchedCharacter(normalizedFamily, weight, width, slant, codepoint, out typeface))
             {
@@ -424,33 +424,9 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         return typeface;
     }
 
-    private bool ShouldUsePlatformCharacterFallback(string? familyName, int codepoint)
-    {
-        return familyName is not null || codepoint > 0x007F || HasNonPlatformTypefaceProviders();
-    }
-
     private static string? GetExplicitFamilyName(ShimSkiaSharp.SKTypeface? typeface)
     {
         return SkiaModel.HasExplicitTypeface(typeface) ? typeface!.FamilyName : null;
-    }
-
-    private bool HasNonPlatformTypefaceProviders()
-    {
-        var providers = _skiaModel.Settings.TypefaceProviders;
-        if (providers is null)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < providers.Count; i++)
-        {
-            if (providers[i] is not FontManagerTypefaceProvider and not DefaultTypefaceProvider)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static SkiaSharp.SKTypeface? MatchPlatformCharacter(

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -54,7 +54,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : weight;
         var width = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var slant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
-        var preferredFamily = preferredTypeface?.FamilyName;
+        var preferredFamily = GetExplicitFamilyName(preferredTypeface);
         System.Func<int, SkiaSharp.SKTypeface?> matchCharacter = codepoint =>
             MatchCharacter(preferredFamily, weight, width, slant, codepoint);
 
@@ -137,7 +137,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
         var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : preferredWeight;
         var preferredWidth = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var preferredSlant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
-        var preferredFamily = preferredTypeface?.FamilyName;
+        var preferredFamily = GetExplicitFamilyName(preferredTypeface);
 
         var candidates = new List<SkiaSharp.SKTypeface?>();
         void AddCandidate(SkiaSharp.SKTypeface? candidate)
@@ -427,6 +427,11 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
     private bool ShouldUsePlatformCharacterFallback(string? familyName, int codepoint)
     {
         return familyName is not null || codepoint > 0x007F || HasNonPlatformTypefaceProviders();
+    }
+
+    private static string? GetExplicitFamilyName(ShimSkiaSharp.SKTypeface? typeface)
+    {
+        return SkiaModel.HasExplicitTypeface(typeface) ? typeface!.FamilyName : null;
     }
 
     private bool HasNonPlatformTypefaceProviders()

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -293,9 +293,10 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
                 {
                     hash = (hash * 397) ^ (custom.Typeface?.Handle.GetHashCode() ?? 0);
                 }
-                else if (provider is FontManagerTypefaceProvider fontManagerProvider)
+                else if (provider is FontManagerTypefaceProvider fontManagerProvider &&
+                         fontManagerProvider.TryGetFontManagerHandle(out var handle))
                 {
-                    hash = (hash * 397) ^ (fontManagerProvider.FontManager?.Handle.GetHashCode() ?? 0);
+                    hash = (hash * 397) ^ handle.GetHashCode();
                 }
             }
 

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -194,7 +194,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
     /// <inheritdoc />
     public ShimSkiaSharp.SKFontMetrics GetFontMetrics(ShimSkiaSharp.SKPaint paint)
     {
-        using var skPaint = _skiaModel.ToSKPaint(paint);
+        using var skPaint = _skiaModel.ToSKTextPaint(paint);
         if (skPaint is null)
         {
             return default;
@@ -218,7 +218,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
     /// <inheritdoc />
     public float MeasureText(string? text, ShimSkiaSharp.SKPaint paint, ref ShimSkiaSharp.SKRect bounds)
     {
-        var skPaint = GetCachedPaint(paint);
+        using var skPaint = _skiaModel.ToSKTextPaint(paint);
         if (skPaint is null || text is null)
         {
             bounds = default;
@@ -247,7 +247,7 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
     /// <inheritdoc />
     public ShimSkiaSharp.SKPath? GetTextPath(string? text, ShimSkiaSharp.SKPaint paint, float x, float y)
     {
-        var skPaint = GetCachedPaint(paint);
+        using var skPaint = _skiaModel.ToSKTextPaint(paint);
         if (skPaint is null || text is null)
         {
             return null;

--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -49,20 +49,21 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
 
         EnsureTypefaceProviderCaches();
 
+        using var runningPaint = _skiaModel.ToSKTextPaint(paintPreferredTypeface);
+        if (runningPaint is null)
+        {
+            return ret;
+        }
+
         var preferredTypeface = paintPreferredTypeface.Typeface;
         var weight = _skiaModel.ToSKFontStyleWeight(preferredTypeface?.FontWeight ?? ShimSkiaSharp.SKFontStyleWeight.Normal);
         var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : weight;
         var width = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var slant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
-        var preferredFamily = GetExplicitFamilyName(preferredTypeface);
+        var preferredFamily = GetExplicitFamilyName(preferredTypeface) ??
+                              (preferredTypeface is null ? null : runningPaint.Typeface?.FamilyName);
         System.Func<int, SkiaSharp.SKTypeface?> matchCharacter = codepoint =>
             MatchCharacter(preferredFamily, weight, width, slant, codepoint);
-
-        using var runningPaint = _skiaModel.ToSKPaint(paintPreferredTypeface);
-        if (runningPaint is null)
-        {
-            return ret;
-        }
 
         var currentTypefaceStartIndex = 0;
         var i = 0;
@@ -132,12 +133,14 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             return paintPreferredTypeface.Typeface;
         }
 
+        using var preferredPaint = _skiaModel.ToSKTextPaint(paintPreferredTypeface);
         var preferredTypeface = paintPreferredTypeface.Typeface;
         var preferredWeight = _skiaModel.ToSKFontStyleWeight(preferredTypeface?.FontWeight ?? ShimSkiaSharp.SKFontStyleWeight.Normal);
         var requestedWeight = preferredTypeface is null ? default(SkiaSharp.SKFontStyleWeight?) : preferredWeight;
         var preferredWidth = _skiaModel.ToSKFontStyleWidth(preferredTypeface?.FontWidth ?? ShimSkiaSharp.SKFontStyleWidth.Normal);
         var preferredSlant = _skiaModel.ToSKFontStyleSlant(preferredTypeface?.FontSlant ?? ShimSkiaSharp.SKFontStyleSlant.Upright);
-        var preferredFamily = GetExplicitFamilyName(preferredTypeface);
+        var preferredFamily = GetExplicitFamilyName(preferredTypeface) ??
+                              (preferredTypeface is null ? null : preferredPaint?.Typeface?.FamilyName);
 
         var candidates = new List<SkiaSharp.SKTypeface?>();
         void AddCandidate(SkiaSharp.SKTypeface? candidate)
@@ -161,7 +164,6 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgTextR
             candidates.Add(candidate);
         }
 
-        using var preferredPaint = _skiaModel.ToSKPaint(paintPreferredTypeface);
         AddCandidate(preferredPaint?.Typeface);
 
         var spans = FindTypefaces(text, paintPreferredTypeface);

--- a/src/Svg.Skia/TypefaceProviders/FontManagerTypefaceProvider.cs
+++ b/src/Svg.Skia/TypefaceProviders/FontManagerTypefaceProvider.cs
@@ -9,6 +9,7 @@ namespace Svg.Skia.TypefaceProviders;
 public sealed class FontManagerTypefaceProvider : ITypefaceProvider
 {
     public static readonly char[] s_fontFamilyTrim = { '\'' };
+    private SkiaSharp.SKFontManager? _fontManager;
 
     private static bool IsGenericFamilyName(string familyName)
     {
@@ -19,11 +20,20 @@ public sealed class FontManagerTypefaceProvider : ITypefaceProvider
                familyName.Equals("fantasy", StringComparison.OrdinalIgnoreCase);
     }
 
-    public SkiaSharp.SKFontManager FontManager { get; set; }
+    public SkiaSharp.SKFontManager FontManager
+    {
+        get => _fontManager ??= SkiaSharp.SKFontManager.Default;
+        set => _fontManager = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     public FontManagerTypefaceProvider()
     {
-        FontManager = SkiaSharp.SKFontManager.Default;
+    }
+
+    internal bool TryGetFontManagerHandle(out IntPtr handle)
+    {
+        handle = _fontManager?.Handle ?? IntPtr.Zero;
+        return handle != IntPtr.Zero;
     }
 
     public SkiaSharp.SKTypeface CreateTypeface(Stream stream, int index = 0)

--- a/src/Svg.Skia/TypefaceProviders/SharedTypefaceCache.cs
+++ b/src/Svg.Skia/TypefaceProviders/SharedTypefaceCache.cs
@@ -270,9 +270,14 @@ internal static class SharedTypefaceCache
                 key = new ProviderTypefaceKey(ProviderKind.Default, IntPtr.Zero, familyName, weight, width, slant);
                 return true;
             case FontManagerTypefaceProvider fontManagerProvider:
-                var handle = fontManagerProvider.FontManager?.Handle ?? IntPtr.Zero;
+                if (!fontManagerProvider.TryGetFontManagerHandle(out var handle))
+                {
+                    key = default;
+                    return false;
+                }
+
                 key = new ProviderTypefaceKey(ProviderKind.FontManager, handle, familyName, weight, width, slant);
-                return handle != IntPtr.Zero;
+                return true;
             default:
                 key = default;
                 return false;

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using SkiaSharp;
 using Svg;
 using Svg.Skia.TypefaceProviders;
@@ -185,12 +186,8 @@ public class SKSvgSettingsTests : SvgUnitTest
     public void FontManagerTypefaceProvider_DoesNotLoadDefaultFontManagerInConstructor()
     {
         var provider = new FontManagerTypefaceProvider();
-        var field = typeof(FontManagerTypefaceProvider).GetField(
-            "_fontManager",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
-        Assert.NotNull(field);
-        Assert.Null(field!.GetValue(provider));
+        Assert.Null(GetFontManager(provider));
     }
 
     [Fact]
@@ -219,6 +216,73 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void ToSKPaint_WithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        using var paint = model.ToSKPaint(source);
+
+        Assert.NotNull(paint);
+#pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
+        Assert.Null(paint!.Typeface);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void ToSKFont_WithoutTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+
+        using var font = model.ToSKFont(new ShimPaint());
+
+        Assert.Null(font.Typeface);
+    }
+
+    [Fact]
+    public void ToSKFont_FontWithoutTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+
+        using var font = model.ToSKFont(new ShimSkiaSharp.SKFont());
+
+        Assert.NotNull(font);
+        Assert.Null(font!.Typeface);
+    }
+
+    [Fact]
+    public void ToSKFont_WithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        using var font = model.ToSKFont(source);
+
+        Assert.Null(font.Typeface);
+    }
+
+    [Fact]
+    public void ToSKFont_FontWithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimSkiaSharp.SKFont
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        using var font = model.ToSKFont(source);
+
+        Assert.NotNull(font);
+        Assert.Null(font!.Typeface);
+    }
+
+    [Fact]
     public void GetRenderPaint_WithoutTypeface_DoesNotResolveDefaultTypeface()
     {
         var model = new SkiaModel(new SKSvgSettings());
@@ -231,6 +295,104 @@ public class SKSvgSettingsTests : SvgUnitTest
 #pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
         Assert.Null(paint.Typeface);
 #pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void GetRenderPaint_WithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var method = typeof(SkiaModel).GetMethod(
+            "GetRenderPaint",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        using var paint = Assert.IsType<SKPaint>(method!.Invoke(model, new object?[] { source }));
+
+#pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
+        Assert.Null(paint.Typeface);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void ToWireframePaint_WithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var method = typeof(SkiaModel).GetMethod(
+            "ToWireframePaint",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        using var paint = Assert.IsType<SKPaint>(method!.Invoke(model, new object?[] { source }));
+
+#pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
+        Assert.Null(paint.Typeface);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void FindTypefaces_WithImplicitTypeface_DoesNotResolvePlatformTypeface()
+    {
+        var provider = new FontManagerTypefaceProvider();
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        var span = Assert.Single(assetLoader.FindTypefaces("I L1", source));
+
+        Assert.Equal("I L1", span.Text);
+        Assert.Null(span.Typeface);
+        Assert.Null(GetFontManager(provider));
+    }
+
+    [Fact]
+    public void FindRunTypeface_WithImplicitTypeface_DoesNotResolvePlatformTypeface()
+    {
+        var provider = new FontManagerTypefaceProvider();
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        var typeface = assetLoader.FindRunTypeface("I L1", source);
+
+        Assert.Null(typeface);
+        Assert.Null(GetFontManager(provider));
+    }
+
+    private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface()
+    {
+        return ShimSkiaSharp.SKTypeface.FromFamilyName(
+            null!,
+            ShimSkiaSharp.SKFontStyleWeight.Normal,
+            ShimSkiaSharp.SKFontStyleWidth.Normal,
+            ShimSkiaSharp.SKFontStyleSlant.Upright);
+    }
+
+    private static object? GetFontManager(FontManagerTypefaceProvider provider)
+    {
+        var field = typeof(FontManagerTypefaceProvider).GetField(
+            "_fontManager",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+        return field!.GetValue(provider);
     }
 
     private sealed class TestJavaScriptRuntimeFactory : ISKSvgJavaScriptRuntimeFactory

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -316,6 +316,23 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void ToSKFont_WithImplicitCondensedTypeface_PreservesWidthForText()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var sourceTypeface = CreateImplicitTypeface(fontWidth: ShimSkiaSharp.SKFontStyleWidth.Condensed);
+        var source = new ShimPaint
+        {
+            Typeface = sourceTypeface
+        };
+        var expectedTypeface = model.ToSKTypeface(sourceTypeface);
+
+        using var font = model.ToSKFont(source);
+
+        Assert.NotNull(font.Typeface);
+        Assert.Equal(expectedTypeface?.FontWidth, font.Typeface!.FontWidth);
+    }
+
+    [Fact]
     public void ToSKFont_FontWithImplicitTypeface_ResolvesDefaultTypefaceForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
@@ -400,12 +417,13 @@ public class SKSvgSettingsTests : SvgUnitTest
 
     private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface(
         ShimSkiaSharp.SKFontStyleWeight fontWeight = ShimSkiaSharp.SKFontStyleWeight.Normal,
+        ShimSkiaSharp.SKFontStyleWidth fontWidth = ShimSkiaSharp.SKFontStyleWidth.Normal,
         ShimSkiaSharp.SKFontStyleSlant fontSlant = ShimSkiaSharp.SKFontStyleSlant.Upright)
     {
         return ShimSkiaSharp.SKTypeface.FromFamilyName(
             null!,
             fontWeight,
-            ShimSkiaSharp.SKFontStyleWidth.Normal,
+            fontWidth,
             fontSlant);
     }
 

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -363,6 +363,44 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void FindTypefaces_WithImplicitItalicTypeface_MatchesResolvedTextTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var assetLoader = new SkiaSvgAssetLoader(model);
+        var sourceTypeface = CreateImplicitTypeface(fontSlant: ShimSkiaSharp.SKFontStyleSlant.Italic);
+        var source = new ShimPaint
+        {
+            Typeface = sourceTypeface
+        };
+        var expectedTypeface = model.ToSKTypeface(sourceTypeface);
+
+        var span = Assert.Single(assetLoader.FindTypefaces("ABC", source));
+
+        Assert.NotNull(expectedTypeface);
+        Assert.NotNull(span.Typeface);
+        Assert.Equal((ShimSkiaSharp.SKFontStyleSlant)expectedTypeface!.FontSlant, span.Typeface!.FontSlant);
+    }
+
+    [Fact]
+    public void FindRunTypeface_WithImplicitCondensedTypeface_MatchesResolvedTextTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var assetLoader = new SkiaSvgAssetLoader(model);
+        var sourceTypeface = CreateImplicitTypeface(fontWidth: ShimSkiaSharp.SKFontStyleWidth.Condensed);
+        var source = new ShimPaint
+        {
+            Typeface = sourceTypeface
+        };
+        var expectedTypeface = model.ToSKTypeface(sourceTypeface);
+
+        var runTypeface = assetLoader.FindRunTypeface("ABC", source);
+
+        Assert.NotNull(expectedTypeface);
+        Assert.NotNull(runTypeface);
+        Assert.Equal((ShimSkiaSharp.SKFontStyleWidth)expectedTypeface!.FontWidth, runTypeface!.FontWidth);
+    }
+
+    [Fact]
     public void GetRenderPaint_WithoutTypeface_DoesNotResolveDefaultTypeface()
     {
         var model = new SkiaModel(new SKSvgSettings());

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -368,94 +368,11 @@ public class SKSvgSettingsTests : SvgUnitTest
 #pragma warning restore CS0618
     }
 
-    [Fact]
-    public void FindTypefaces_WithImplicitTypeface_DoesNotResolvePlatformTypeface()
-    {
-        var provider = new FontManagerTypefaceProvider();
-        var settings = new SKSvgSettings
-        {
-            TypefaceProviders = new List<ITypefaceProvider> { provider }
-        };
-        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
-        var source = new ShimPaint
-        {
-            Typeface = CreateImplicitTypeface()
-        };
-
-        var span = Assert.Single(assetLoader.FindTypefaces("I L1", source));
-
-        Assert.Equal("I L1", span.Text);
-        Assert.Null(span.Typeface);
-        Assert.Null(GetFontManager(provider));
-    }
-
-    [Fact]
-    public void FindTypefaces_WithBlankFamilyTypeface_DoesNotResolvePlatformTypeface()
-    {
-        var provider = new FontManagerTypefaceProvider();
-        var settings = new SKSvgSettings
-        {
-            TypefaceProviders = new List<ITypefaceProvider> { provider }
-        };
-        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
-        var source = new ShimPaint
-        {
-            Typeface = CreateImplicitTypeface(string.Empty)
-        };
-
-        var span = Assert.Single(assetLoader.FindTypefaces("I L1", source));
-
-        Assert.Equal("I L1", span.Text);
-        Assert.Null(span.Typeface);
-        Assert.Null(GetFontManager(provider));
-    }
-
-    [Fact]
-    public void FindRunTypeface_WithImplicitTypeface_DoesNotResolvePlatformTypeface()
-    {
-        var provider = new FontManagerTypefaceProvider();
-        var settings = new SKSvgSettings
-        {
-            TypefaceProviders = new List<ITypefaceProvider> { provider }
-        };
-        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
-        var source = new ShimPaint
-        {
-            Typeface = CreateImplicitTypeface()
-        };
-
-        var typeface = assetLoader.FindRunTypeface("I L1", source);
-
-        Assert.Null(typeface);
-        Assert.Null(GetFontManager(provider));
-    }
-
-    [Fact]
-    public void FindRunTypeface_WithBlankFamilyTypeface_DoesNotResolvePlatformTypeface()
-    {
-        var provider = new FontManagerTypefaceProvider();
-        var settings = new SKSvgSettings
-        {
-            TypefaceProviders = new List<ITypefaceProvider> { provider }
-        };
-        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
-        var source = new ShimPaint
-        {
-            Typeface = CreateImplicitTypeface(string.Empty)
-        };
-
-        var typeface = assetLoader.FindRunTypeface("I L1", source);
-
-        Assert.Null(typeface);
-        Assert.Null(GetFontManager(provider));
-    }
-
     private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface(
-        string? familyName = null,
         ShimSkiaSharp.SKFontStyleWeight fontWeight = ShimSkiaSharp.SKFontStyleWeight.Normal)
     {
         return ShimSkiaSharp.SKTypeface.FromFamilyName(
-            familyName!,
+            null!,
             fontWeight,
             ShimSkiaSharp.SKFontStyleWidth.Normal,
             ShimSkiaSharp.SKFontStyleSlant.Upright);

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -4,6 +4,7 @@ using Svg;
 using Svg.Skia.TypefaceProviders;
 using Svg.Skia.UnitTests.Common;
 using Xunit;
+using ShimPaint = ShimSkiaSharp.SKPaint;
 
 namespace Svg.Skia.UnitTests;
 
@@ -181,6 +182,18 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void FontManagerTypefaceProvider_DoesNotLoadDefaultFontManagerInConstructor()
+    {
+        var provider = new FontManagerTypefaceProvider();
+        var field = typeof(FontManagerTypefaceProvider).GetField(
+            "_fontManager",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+        Assert.Null(field!.GetValue(provider));
+    }
+
+    [Fact]
     public void FontManagerTypefaceProvider_AllowsExplicitDefaultFamilyRequest()
     {
         var provider = new FontManagerTypefaceProvider();
@@ -190,6 +203,34 @@ public class SKSvgSettingsTests : SvgUnitTest
 
         Assert.NotNull(typeface);
         Assert.Equal(familyName, typeface!.FamilyName);
+    }
+
+    [Fact]
+    public void ToSKPaint_WithoutTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+
+        using var paint = model.ToSKPaint(new ShimPaint());
+
+        Assert.NotNull(paint);
+#pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
+        Assert.Null(paint!.Typeface);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void GetRenderPaint_WithoutTypeface_DoesNotResolveDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var method = typeof(SkiaModel).GetMethod(
+            "GetRenderPaint",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        using var paint = Assert.IsType<SKPaint>(method!.Invoke(model, new object?[] { new ShimPaint() }));
+
+#pragma warning disable CS0618 // SKPaint.Typeface is verified here to avoid loading the default platform typeface.
+        Assert.Null(paint.Typeface);
+#pragma warning restore CS0618
     }
 
     private sealed class TestJavaScriptRuntimeFactory : ISKSvgJavaScriptRuntimeFactory

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -251,28 +251,28 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
-    public void ToSKFont_WithoutTypeface_DoesNotResolveDefaultTypeface()
+    public void ToSKFont_WithoutTypeface_ResolvesDefaultTypefaceForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
 
         using var font = model.ToSKFont(new ShimPaint());
 
-        Assert.Null(font.Typeface);
+        Assert.NotNull(font.Typeface);
     }
 
     [Fact]
-    public void ToSKFont_FontWithoutTypeface_DoesNotResolveDefaultTypeface()
+    public void ToSKFont_FontWithoutTypeface_ResolvesDefaultTypefaceForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
 
         using var font = model.ToSKFont(new ShimSkiaSharp.SKFont());
 
         Assert.NotNull(font);
-        Assert.Null(font!.Typeface);
+        Assert.NotNull(font!.Typeface);
     }
 
     [Fact]
-    public void ToSKFont_WithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    public void ToSKFont_WithImplicitTypeface_ResolvesDefaultTypefaceForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
         var source = new ShimPaint
@@ -282,11 +282,11 @@ public class SKSvgSettingsTests : SvgUnitTest
 
         using var font = model.ToSKFont(source);
 
-        Assert.Null(font.Typeface);
+        Assert.NotNull(font.Typeface);
     }
 
     [Fact]
-    public void ToSKFont_WithImplicitBoldTypeface_EmboldensWithoutResolvingDefaultTypeface()
+    public void ToSKFont_WithImplicitBoldTypeface_PreservesBoldForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
         var source = new ShimPaint
@@ -296,12 +296,27 @@ public class SKSvgSettingsTests : SvgUnitTest
 
         using var font = model.ToSKFont(source);
 
-        Assert.Null(font.Typeface);
-        Assert.True(font.Embolden);
+        Assert.NotNull(font.Typeface);
+        Assert.True(font.Embolden || font.Typeface!.FontWeight >= (int)SKFontStyleWeight.Bold);
     }
 
     [Fact]
-    public void ToSKFont_FontWithImplicitTypeface_DoesNotResolveDefaultTypeface()
+    public void ToSKFont_WithImplicitItalicTypeface_PreservesSlantForText()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface(fontSlant: ShimSkiaSharp.SKFontStyleSlant.Italic)
+        };
+
+        using var font = model.ToSKFont(source);
+
+        Assert.NotNull(font.Typeface);
+        Assert.NotEqual(SKFontStyleSlant.Upright, font.Typeface!.FontSlant);
+    }
+
+    [Fact]
+    public void ToSKFont_FontWithImplicitTypeface_ResolvesDefaultTypefaceForText()
     {
         var model = new SkiaModel(new SKSvgSettings());
         var source = new ShimSkiaSharp.SKFont
@@ -312,7 +327,22 @@ public class SKSvgSettingsTests : SvgUnitTest
         using var font = model.ToSKFont(source);
 
         Assert.NotNull(font);
-        Assert.Null(font!.Typeface);
+        Assert.NotNull(font!.Typeface);
+    }
+
+    [Fact]
+    public void TryShapeGlyphRun_WithImplicitTypeface_UsesDefaultTextTypeface()
+    {
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface()
+        };
+
+        var shaped = assetLoader.TryShapeGlyphRun("ABC", source, out var shapedRun);
+
+        Assert.True(shaped);
+        Assert.NotEmpty(shapedRun.Glyphs);
     }
 
     [Fact]
@@ -369,13 +399,14 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface(
-        ShimSkiaSharp.SKFontStyleWeight fontWeight = ShimSkiaSharp.SKFontStyleWeight.Normal)
+        ShimSkiaSharp.SKFontStyleWeight fontWeight = ShimSkiaSharp.SKFontStyleWeight.Normal,
+        ShimSkiaSharp.SKFontStyleSlant fontSlant = ShimSkiaSharp.SKFontStyleSlant.Upright)
     {
         return ShimSkiaSharp.SKTypeface.FromFamilyName(
             null!,
             fontWeight,
             ShimSkiaSharp.SKFontStyleWidth.Normal,
-            ShimSkiaSharp.SKFontStyleSlant.Upright);
+            fontSlant);
     }
 
     private static object? GetFontManager(FontManagerTypefaceProvider provider)

--- a/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
+++ b/tests/Svg.Skia.UnitTests/SKSvgSettingsTests.cs
@@ -233,6 +233,24 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void ToSKPaint_WithImplicitBoldTypeface_EmboldensWithoutResolvingDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface(fontWeight: ShimSkiaSharp.SKFontStyleWeight.Bold)
+        };
+
+        using var paint = model.ToSKPaint(source);
+
+        Assert.NotNull(paint);
+#pragma warning disable CS0618 // SKPaint.Typeface and FakeBoldText are verified here to avoid loading the default platform typeface.
+        Assert.Null(paint!.Typeface);
+        Assert.True(paint.FakeBoldText);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
     public void ToSKFont_WithoutTypeface_DoesNotResolveDefaultTypeface()
     {
         var model = new SkiaModel(new SKSvgSettings());
@@ -265,6 +283,21 @@ public class SKSvgSettingsTests : SvgUnitTest
         using var font = model.ToSKFont(source);
 
         Assert.Null(font.Typeface);
+    }
+
+    [Fact]
+    public void ToSKFont_WithImplicitBoldTypeface_EmboldensWithoutResolvingDefaultTypeface()
+    {
+        var model = new SkiaModel(new SKSvgSettings());
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface(fontWeight: ShimSkiaSharp.SKFontStyleWeight.Bold)
+        };
+
+        using var font = model.ToSKFont(source);
+
+        Assert.Null(font.Typeface);
+        Assert.True(font.Embolden);
     }
 
     [Fact]
@@ -357,6 +390,27 @@ public class SKSvgSettingsTests : SvgUnitTest
     }
 
     [Fact]
+    public void FindTypefaces_WithBlankFamilyTypeface_DoesNotResolvePlatformTypeface()
+    {
+        var provider = new FontManagerTypefaceProvider();
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface(string.Empty)
+        };
+
+        var span = Assert.Single(assetLoader.FindTypefaces("I L1", source));
+
+        Assert.Equal("I L1", span.Text);
+        Assert.Null(span.Typeface);
+        Assert.Null(GetFontManager(provider));
+    }
+
+    [Fact]
     public void FindRunTypeface_WithImplicitTypeface_DoesNotResolvePlatformTypeface()
     {
         var provider = new FontManagerTypefaceProvider();
@@ -376,11 +430,33 @@ public class SKSvgSettingsTests : SvgUnitTest
         Assert.Null(GetFontManager(provider));
     }
 
-    private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface()
+    [Fact]
+    public void FindRunTypeface_WithBlankFamilyTypeface_DoesNotResolvePlatformTypeface()
+    {
+        var provider = new FontManagerTypefaceProvider();
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider> { provider }
+        };
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(settings));
+        var source = new ShimPaint
+        {
+            Typeface = CreateImplicitTypeface(string.Empty)
+        };
+
+        var typeface = assetLoader.FindRunTypeface("I L1", source);
+
+        Assert.Null(typeface);
+        Assert.Null(GetFontManager(provider));
+    }
+
+    private static ShimSkiaSharp.SKTypeface CreateImplicitTypeface(
+        string? familyName = null,
+        ShimSkiaSharp.SKFontStyleWeight fontWeight = ShimSkiaSharp.SKFontStyleWeight.Normal)
     {
         return ShimSkiaSharp.SKTypeface.FromFamilyName(
-            null!,
-            ShimSkiaSharp.SKFontStyleWeight.Normal,
+            familyName!,
+            fontWeight,
             ShimSkiaSharp.SKFontStyleWidth.Normal,
             ShimSkiaSharp.SKFontStyleSlant.Upright);
     }


### PR DESCRIPTION
## Summary

Fixes eager font-manager side effects in Svg.Skia without trying to mask Alpine Linux native dependency problems.

Issue #531 reports an Alpine ARM64 crash inside SkiaSharp's native fontconfig path while resolving `SKFontManager.Default`. The linked repro already installs `fontconfig` and fonts, but it uses `SkiaSharp.NativeAssets.Linux` under Alpine. The Alpine-specific deployment guidance in https://medo64.com/posts/skiasharp-under-alpine-linux points to using `SkiaSharp.NativeAssets.Linux.NoDependencies` plus `fontconfig` and installed fonts for that environment.

This PR therefore keeps Svg.Skia from initializing the platform font manager as a side effect of settings construction, cache hashing, or non-text paint/font conversion. It does not suppress normal platform font fallback when text rendering actually needs SkiaSharp's font manager.

## Changes

- Make `FontManagerTypefaceProvider` lazy-load `SKFontManager.Default` only when font-manager-backed font resolution is requested.
- Avoid reading the default font manager handle while computing typeface provider cache hashes in `SkiaModel` and `SkiaSvgAssetLoader`.
- Avoid using `FontManagerTypefaceProvider` in the shared provider typeface cache until its font manager has already been initialized.
- Treat shim typefaces with a null or blank `FamilyName` as implicit SVG typefaces instead of resolving them to `SKTypeface.Default` during paint/font conversion.
- Preserve null native typefaces for implicit/no-family paints and fonts in normal rendering, cached render paints, and wireframe paints.
- Preserve synthetic bold for implicit/no-family bold text without resolving a platform typeface.
- Keep normal platform font fallback for actual text runs.
- Document Alpine/minimal Linux deployment guidance for `SkiaSharp.NativeAssets.Linux.NoDependencies`, `fontconfig`, and installed fonts in the README.
- Restore default text typeface resolution for text-specific font/paint paths so implicit-family text still shapes with HarfBuzz and preserves implicit italic/oblique styling.
- Resolve the working text paint before fallback span/run splitting so `FindTypefaces` and `FindRunTypeface` preserve implicit-family italic and condensed text styling.
- Dispose transient text paints used by direct text and text-on-path rendering after text-specific paint resolution.

## Tests

Added regressions covering:

- `FontManagerTypefaceProvider` construction not loading the default font manager.
- `ToSKPaint`, cached render paint, and wireframe paint preserving null native typefaces for implicit/no-family source typefaces.
- `ToSKPaint` preserving synthetic bold for implicit bold typefaces without resolving a platform typeface.
- `ToSKFont` resolving an implicit/default typeface for text rendering.
- `ToSKFont` preserving implicit bold, italic, and condensed-width text styling.
- `TryShapeGlyphRun` shaping implicit-family text with the default text typeface.
- `FindTypefaces` and `FindRunTypeface` matching the resolved text typeface for implicit-family styled text.

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-restore --no-build`
- `git diff --check`

The release build completed with existing warnings and no errors. The full test run passed, including `Svg.Skia.UnitTests` with 1862 passed, 533 skipped, 2395 total.

The README-only follow-up was validated with `git diff --check`; no additional runtime test run was required for the documentation change.

After addressing PR review feedback, the focused `SKSvgSettingsTests`, `Issue405Tests`, and `Issue462Tests` subset passed with 45 tests. The full release test run passed again, including `Svg.Skia.UnitTests` with 1864 passed, 533 skipped, 2397 total. A follow-up focused `SKSvgSettingsTests` run passed with 38 tests after adding explicit coverage for implicit condensed text width.

After the follow-up review about fallback span splitting, the focused `SKSvgSettingsTests`, `Issue405Tests`, and `Issue462Tests` subset passed with 48 tests. `dotnet format Svg.Skia.slnx --no-restore`, `dotnet build Svg.Skia.slnx -c Release --no-restore`, full `dotnet test Svg.Skia.slnx -c Release --no-restore --no-build`, and `git diff --check` passed. The final full release test run included `Svg.Skia.UnitTests` with 1867 passed, 533 skipped, 2400 total.

After the transient text paint disposal review, the focused text/render subset passed with 153 tests. `dotnet format Svg.Skia.slnx --no-restore`, `dotnet build Svg.Skia.slnx -c Release --no-restore`, full `dotnet test Svg.Skia.slnx -c Release --no-restore --no-build`, and `git diff --check` passed. The final full release test run included `Svg.Skia.UnitTests` with 1867 passed, 533 skipped, 2400 total.

I reviewed the issue comment and the `JMS-1/pdf-svg-crash-repro` project. The repro's Dockerfile installs `fontconfig` and fonts, but the project references `SkiaSharp.NativeAssets.Linux`; for Alpine the likely deployment fix is to switch the consuming app to `SkiaSharp.NativeAssets.Linux.NoDependencies` and keep `fontconfig` plus fonts installed. I could not execute the exact Alpine ARM64 Docker repro locally because Docker/Colima was not running and `colima start` failed in this environment.
