### PR TITLE
Fix SvgSource invariant globalization startup failure

### DIFF
--- a/Svg.Skia.slnx
+++ b/Svg.Skia.slnx
@@ -106,6 +106,7 @@
     <Project Path="tests/ShimSkiaSharp.UnitTests/ShimSkiaSharp.UnitTests.csproj" />
     <Project Path="tests/Svg.Skia.Benchmarks/Svg.Skia.Benchmarks.csproj" />
     <Project Path="tests/Svg.Controls.Avalonia.UnitTests/Svg.Controls.Avalonia.UnitTests.csproj" />
+    <Project Path="tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests.csproj" />
     <Project Path="tests/Svg.Controls.Skia.Avalonia.UnitTests/Svg.Controls.Skia.Avalonia.UnitTests.csproj" />
     <Project Path="tests/Svg.Controls.Skia.Uno.UnitTests/Svg.Controls.Skia.Uno.UnitTests.csproj" />
     <Project Path="tests/Svg.Editor.Skia.Avalonia.UnitTests/Svg.Editor.Skia.Avalonia.UnitTests.csproj" />

--- a/src/Svg.Model/Services/SvgService.cs
+++ b/src/Svg.Model/Services/SvgService.cs
@@ -16,7 +16,9 @@ namespace Svg.Model.Services;
 
 public static class SvgService
 {
-    public static CultureInfo? s_systemLanguageOverride = CultureInfo.GetCultureInfo("en-US");
+    private const string DefaultSystemLanguageTag = "en-US";
+
+    public static CultureInfo? s_systemLanguageOverride = TryGetCultureInfo(DefaultSystemLanguageTag);
 
     private static readonly char[] s_spaceTab = { ' ', '\t' };
 
@@ -431,8 +433,7 @@ public static class SvgService
             return false;
         }
 
-        var systemLanguage = s_systemLanguageOverride ?? CultureInfo.InstalledUICulture;
-        var systemLanguageTag = GetSystemLanguageTag(systemLanguage);
+        var systemLanguageTag = GetCurrentSystemLanguageTag();
         if (string.IsNullOrWhiteSpace(systemLanguageTag))
         {
             return false;
@@ -447,6 +448,28 @@ public static class SvgService
         }
 
         return false;
+    }
+
+    private static CultureInfo? TryGetCultureInfo(string name)
+    {
+        try
+        {
+            return CultureInfo.GetCultureInfo(name);
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetCurrentSystemLanguageTag()
+    {
+        if (s_systemLanguageOverride is { } systemLanguageOverride)
+        {
+            return GetSystemLanguageTag(systemLanguageOverride);
+        }
+
+        return GetSystemLanguageTag(CultureInfo.InstalledUICulture) ?? DefaultSystemLanguageTag;
     }
 
     internal static bool PassesConditionalProcessing(this SvgElement svgElement, DrawAttributes ignoreAttributes)

--- a/tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests.csproj
+++ b/tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>False</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Avalonia.Svg.Skia.InvariantGlobalization.UnitTests</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\XUnit.v3.props" />
+  <Import Project="..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\build\SkiaSharp.Native.props" />
+  <Import Project="..\..\build\SkiaSharp.Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Skia.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Svg.Controls.Skia.Avalonia\Svg.Controls.Skia.Avalonia.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/SvgSourceInvariantGlobalizationTests.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/SvgSourceInvariantGlobalizationTests.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using System.IO;
+using Avalonia.Svg.Skia;
+using SkiaSharp;
+using Xunit;
+
+namespace Avalonia.Svg.Skia.InvariantGlobalization.UnitTests;
+
+public class SvgSourceInvariantGlobalizationTests
+{
+    private const string SampleSvg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+          <rect x="0" y="0" width="10" height="10" fill="red" />
+        </svg>
+        """;
+
+    [Fact]
+    public void LoadFromSvg_CreatesPicture_WhenGlobalizationInvariant()
+    {
+        AssertInvariantGlobalization();
+
+        using var source = SvgSource.LoadFromSvg(SampleSvg);
+
+        Assert.NotNull(source.Svg);
+        Assert.NotNull(source.Picture);
+    }
+
+    [Fact]
+    public void Load_FilePathCreatesPicture_WhenGlobalizationInvariant()
+    {
+        AssertInvariantGlobalization();
+
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.svg");
+        File.WriteAllText(path, SampleSvg);
+
+        try
+        {
+            using var source = SvgSource.Load(path);
+
+            Assert.NotNull(source.Svg);
+            Assert.NotNull(source.Picture);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadFromSvg_UsesDeterministicDefaultSystemLanguage_WhenGlobalizationInvariant()
+    {
+        AssertInvariantGlobalization();
+
+        const string svgMarkup = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+              <switch>
+                <rect width="40" height="40" fill="#00ff00" systemLanguage="en-US" />
+                <rect width="40" height="40" fill="#ff0000" />
+              </switch>
+            </svg>
+            """;
+
+        using var source = SvgSource.LoadFromSvg(svgMarkup);
+        using var bitmap = RenderBitmap(source.Svg!, 40, 40);
+
+        AssertMostlyGreen(bitmap.GetPixel(20, 20));
+    }
+
+    private static void AssertInvariantGlobalization()
+    {
+        Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo("en-US"));
+    }
+
+    private static SKBitmap RenderBitmap(global::Svg.Skia.SKSvg svg, int width, int height)
+    {
+        var picture = svg.Picture;
+        Assert.NotNull(picture);
+
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul));
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+        canvas.DrawPicture(picture);
+        return bitmap;
+    }
+
+    private static void AssertMostlyGreen(SKColor color)
+    {
+        Assert.True(
+            color.Green > 180 && color.Red < 80 && color.Blue < 80 && color.Alpha > 220,
+            $"Expected mostly green, got {color}.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #541 by making `SvgService` safe to initialize when .NET runs in invariant globalization mode.

The previous `SvgService` static field eagerly called `CultureInfo.GetCultureInfo("en-US")`. In invariant globalization mode, named culture lookup throws `CultureNotFoundException`, which caused the whole `SvgService` type initializer to fail before an SVG could be loaded. That surfaced through `Svg.Controls.Skia.Avalonia` as a `TypeInitializationException` from `SvgSource.Load(...)`.

This change keeps the existing deterministic `en-US` default for SVG `systemLanguage` matching, but avoids doing a throwing named-culture lookup during static initialization. If the runtime cannot create the named culture, `SvgService` falls back to the language tag string for conditional processing while still allowing tests and callers to override `s_systemLanguageOverride`.

## Changes

- Added a non-throwing culture lookup helper for the default `en-US` system language.
- Centralized current system-language tag selection so invariant globalization still resolves the default `en-US` behavior.
- Added an invariant-globalization test project for `Svg.Controls.Skia.Avalonia`.
- Covered both inline SVG loading and file-path SVG loading through `SvgSource`.
- Added coverage that `systemLanguage="en-US"` still selects the expected branch under invariant globalization.

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release`
- `dotnet test Svg.Skia.slnx -c Release`
- `dotnet test tests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests/Svg.Controls.Skia.Avalonia.InvariantGlobalization.UnitTests.csproj -c Release --filter "FullyQualifiedName~SvgSourceInvariantGlobalizationTests"`
- `dotnet test tests/Svg.Model.UnitTests/Svg.Model.UnitTests.csproj -f net10.0 -c Release --no-restore --filter "FullyQualifiedName~SvgConditionalProcessingTests"`
