### PR TITLE
Strong-name sign all packaged assemblies

### DIFF
--- a/src/Skia.Controls.Avalonia/Skia.Controls.Avalonia.csproj
+++ b/src/Skia.Controls.Avalonia/Skia.Controls.Avalonia.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\SourceLink.props" />
-  <!--<Import Project="..\..\build\SignAssembly.props" />-->
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
 

--- a/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
+++ b/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\SourceLink.props" />
-  <!--<Import Project="..\..\build\SignAssembly.props" />-->
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
 

--- a/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\SourceLink.props" />
-  <!--<Import Project="..\..\build\SignAssembly.props" />-->
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.Skia.props" />
 

--- a/src/Svg.Controls.Skia.Uno/Properties/AssemblyInfo.cs
+++ b/src/Svg.Controls.Skia.Uno/Properties/AssemblyInfo.cs
@@ -1,3 +1,8 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Svg.Controls.Skia.Uno.UnitTests")]
+[assembly: InternalsVisibleTo("Svg.Controls.Skia.Uno.UnitTests,PublicKey=" +
+"00240000048000009400000006020000002400005253413100040000010001000958ee05055101" +
+"5f5db159c2fcc56a83ca8a54083e1ac6cac40312e0b0dcb26ce9e1cba2358c8644ffd7b21efbbc" +
+"1304b44f6d6487c23218986ab356ce0461e2e8886d8269a47e534b4a48310151719fdfdde82aad" +
+"3667eb87baad62c7bb7cf826a4095229fbed8904f90cf9dc553c9ad5d6a3e543058847431fdda7" +
+"58211bd3")]

--- a/src/Svg.Controls.Skia.Uno/Svg.Controls.Skia.Uno.csproj
+++ b/src/Svg.Controls.Skia.Uno/Svg.Controls.Skia.Uno.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\SourceLink.props" />
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
 
   <ItemGroup>

--- a/src/SvgML.Uno/SvgML.Uno.csproj
+++ b/src/SvgML.Uno/SvgML.Uno.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\SourceLink.props" />
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SvgML.Weaving.targets" />
 

--- a/tests/Svg.Controls.Skia.Uno.UnitTests/Svg.Controls.Skia.Uno.UnitTests.csproj
+++ b/tests/Svg.Controls.Skia.Uno.UnitTests/Svg.Controls.Skia.Uno.UnitTests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SkiaSharp.Native.props" />


### PR DESCRIPTION
## Summary

Strong-name sign every first-party assembly currently shipped from a packable project.

This restores the repository's existing signing policy to the three Avalonia packages whose signing imports were commented out and applies the same policy to the newer Uno packages.

## Root cause

Svg.Skia already keeps a strong-name key and central `build/SignAssembly.props` settings, and most packages import them. Five packable projects did not:

- `Skia.Controls.Avalonia`
- `Svg.Controls.Avalonia`
- `Svg.Controls.Skia.Avalonia`
- `Svg.Controls.Skia.Uno`
- `SvgML.Uno`

The Uno control also exposes internals to its test assembly. Once the production assembly is signed, .NET requires that friend assembly declaration to include the full public key and that the test assembly be signed with the matching key.

## Changes

- enable the shared strong-name settings in all five previously unsigned package projects
- sign `Svg.Controls.Skia.Uno.UnitTests` with the same repository key
- qualify the Uno test `InternalsVisibleTo` declaration with the matching public key

All affected assemblies now use public key token `dafe96fe6c845a74`, consistent with the rest of the package family.

This addresses strong-name assembly signing, matching the request and prior #19 implementation. It does not add Authenticode publisher signing, which would require a separately managed trusted code-signing certificate.

## Impact

Consumers that require strong-named dependencies can use the Avalonia and Uno packages without encountering unsigned Svg.Skia assemblies. The change also makes assembly identity consistent across the complete first-party package set.

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-restore`
  - 3,109 passed
  - 40 skipped
  - 0 failed
- verified all five affected Release DLLs with `sn -T` and `sn -vf`

Fixes #535