### PR TITLE
Honor variable font weights during text shaping

### DIFF
--- a/src/Svg.Skia/SkiaModel.TextShaping.cs
+++ b/src/Svg.Skia/SkiaModel.TextShaping.cs
@@ -756,9 +756,31 @@ public partial class SkiaModel
             var font = new Font(face);
             font.SetScale(HarfBuzzFontScale, HarfBuzzFontScale);
             font.SetFunctionsOpenType();
+            ApplyVariations(typeface, font);
 
             shaper = new HarfBuzzTextShaper(typeface, font);
             return true;
+        }
+
+        private static void ApplyVariations(SkiaSharp.SKTypeface typeface, Font font)
+        {
+            var position = typeface.VariationDesignPosition;
+            if (position.Length == 0)
+            {
+                return;
+            }
+
+            var variations = new Variation[position.Length];
+            for (var i = 0; i < position.Length; i++)
+            {
+                variations[i] = new Variation
+                {
+                    Tag = position[i].Axis,
+                    Value = position[i].Value
+                };
+            }
+
+            font.SetVariations(variations);
         }
 
         public SkiaSharp.SKTypeface Typeface { get; }

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -587,7 +587,8 @@ public partial class SkiaModel
                 var providerTypeface = ResolveProviderTypeface(typefaceProvider, candidate, fontWeight, fontWidth, fontStyle);
                 if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                 {
-                    return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider, candidate, providerTypeface));
+                    var resolvedProviderTypeface = ApplyVariableFontWeight(providerTypeface, style);
+                    return CacheTypefaceResolution(cacheKey, resolvedProviderTypeface, ShouldSuppressSyntheticBold(typefaceProvider, candidate, resolvedProviderTypeface));
                 }
             }
 
@@ -609,7 +610,8 @@ public partial class SkiaModel
                     var providerTypeface = ResolveProviderTypeface(typefaceProvider, candidate, fontWeight, fontWidth, fontStyle);
                     if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
                     {
-                        return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider, candidate, providerTypeface));
+                        var resolvedProviderTypeface = ApplyVariableFontWeight(providerTypeface, style);
+                        return CacheTypefaceResolution(cacheKey, resolvedProviderTypeface, ShouldSuppressSyntheticBold(typefaceProvider, candidate, resolvedProviderTypeface));
                     }
                 }
 
@@ -628,7 +630,8 @@ public partial class SkiaModel
             var providerTypeface = ResolveProviderTypeface(typefaceProvider, SkiaSharp.SKTypeface.Default.FamilyName, fontWeight, fontWidth, fontStyle);
             if (providerTypeface is { } && providerTypeface.Handle != IntPtr.Zero)
             {
-                return CacheTypefaceResolution(cacheKey, providerTypeface, ShouldSuppressSyntheticBold(typefaceProvider, SkiaSharp.SKTypeface.Default.FamilyName, providerTypeface));
+                var resolvedProviderTypeface = ApplyVariableFontWeight(providerTypeface, style);
+                return CacheTypefaceResolution(cacheKey, resolvedProviderTypeface, ShouldSuppressSyntheticBold(typefaceProvider, SkiaSharp.SKTypeface.Default.FamilyName, resolvedProviderTypeface));
             }
         }
 
@@ -675,7 +678,76 @@ public partial class SkiaModel
         }
 
         restyled?.Dispose();
+
+        var varied = ApplyVariableFontWeight(resolved, style);
+        if (!ReferenceEquals(varied, resolved))
+        {
+            resolved.Dispose();
+            return varied;
+        }
+
         return resolved;
+    }
+
+    private static SkiaSharp.SKTypeface ApplyVariableFontWeight(
+        SkiaSharp.SKTypeface typeface,
+        SkiaSharp.SKFontStyle style)
+    {
+        var axes = typeface.VariationDesignParameters;
+        if (axes.Length == 0)
+        {
+            return typeface;
+        }
+
+        var weightTag = SkiaSharp.SKFourByteTag.Parse("wght");
+        var weightAxis = default(SkiaSharp.SKFontVariationAxis?);
+        for (var i = 0; i < axes.Length; i++)
+        {
+            if (axes[i].Tag == weightTag)
+            {
+                weightAxis = axes[i];
+                break;
+            }
+        }
+
+        if (weightAxis is not { } axis)
+        {
+            return typeface;
+        }
+
+        var requestedWeight = Math.Min(Math.Max(style.Weight, axis.Min), axis.Max);
+        var position = typeface.VariationDesignPosition;
+        var weightCoordinateIndex = -1;
+        for (var i = 0; i < position.Length; i++)
+        {
+            if (position[i].Axis == weightTag)
+            {
+                weightCoordinateIndex = i;
+                break;
+            }
+        }
+
+        if (weightCoordinateIndex >= 0 && position[weightCoordinateIndex].Value == requestedWeight)
+        {
+            return typeface;
+        }
+
+        if (weightCoordinateIndex < 0)
+        {
+            Array.Resize(ref position, position.Length + 1);
+            weightCoordinateIndex = position.Length - 1;
+            position[weightCoordinateIndex].Axis = weightTag;
+        }
+
+        position[weightCoordinateIndex].Value = requestedWeight;
+        var varied = typeface.Clone(position);
+        if (varied is { } && varied.Handle != IntPtr.Zero)
+        {
+            return varied;
+        }
+
+        varied?.Dispose();
+        return typeface;
     }
 
     private static bool IsExactStyleMatch(SkiaSharp.SKTypeface typeface, SkiaSharp.SKFontStyle style)

--- a/tests/Svg.Skia.UnitTests/Issue543Tests.cs
+++ b/tests/Svg.Skia.UnitTests/Issue543Tests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using ShimSkiaSharp;
+using Svg.Skia.TypefaceProviders;
+using Svg.Skia.UnitTests.Common;
+using Xunit;
+
+namespace Svg.Skia.UnitTests;
+
+public class Issue543Tests : SvgUnitTest
+{
+    [Fact]
+    public void VariableFontProviderAppliesRequestedWeightAxis()
+    {
+        using var typeface = SkiaSharp.SKTypeface.FromFile(GetFontsPath("RobotoFlex.subset.ttf"));
+        Assert.NotNull(typeface);
+
+        var settings = new SKSvgSettings
+        {
+            TypefaceProviders = new List<ITypefaceProvider>
+            {
+                new AliasTypefaceProvider("Issue543-Variable", typeface!)
+            }
+        };
+        var model = new SkiaModel(settings);
+        var paint = new SKPaint
+        {
+            TextSize = 117.333f,
+            Typeface = SKTypeface.FromFamilyName(
+                "Issue543-Variable",
+                SKFontStyleWeight.Black,
+                SKFontStyleWidth.Normal,
+                SKFontStyleSlant.Upright)
+        };
+
+        using var skFont = model.ToSKFont(paint);
+
+        Assert.NotNull(skFont.Typeface);
+        Assert.Equal((int)SkiaSharp.SKFontStyleWeight.Black, skFont.Typeface!.FontWeight);
+        var weight = Assert.Single(
+            skFont.Typeface.VariationDesignPosition,
+            static coordinate => coordinate.Axis == SkiaSharp.SKFourByteTag.Parse("wght"));
+        Assert.Equal(900f, weight.Value);
+        Assert.False(skFont.Embolden);
+
+        var loader = new SkiaSvgAssetLoader(model);
+        Assert.True(loader.TryShapeGlyphRun("EK", paint, out var heavyRun));
+
+        paint.Typeface = SKTypeface.FromFamilyName(
+            "Issue543-Variable",
+            SKFontStyleWeight.Normal,
+            SKFontStyleWidth.Normal,
+            SKFontStyleSlant.Upright);
+        Assert.True(loader.TryShapeGlyphRun("EK", paint, out var normalRun));
+        Assert.True(heavyRun.Advance > normalRun.Advance);
+    }
+
+    private sealed class AliasTypefaceProvider : ITypefaceProvider
+    {
+        private readonly string _familyName;
+        private readonly SkiaSharp.SKTypeface _typeface;
+
+        public AliasTypefaceProvider(string familyName, SkiaSharp.SKTypeface typeface)
+        {
+            _familyName = familyName;
+            _typeface = typeface;
+        }
+
+        public SkiaSharp.SKTypeface? FromFamilyName(
+            string fontFamily,
+            SkiaSharp.SKFontStyleWeight fontWeight,
+            SkiaSharp.SKFontStyleWidth fontWidth,
+            SkiaSharp.SKFontStyleSlant fontStyle)
+        {
+            return string.Equals(fontFamily, _familyName, StringComparison.Ordinal)
+                ? _typeface
+                : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- instantiate variable typefaces at the SVG/CSS-requested `wght` coordinate
- preserve the font's other variation coordinates when cloning the Skia typeface
- pass the resolved variation position into HarfBuzz when shaping text
- add a portable Roboto Flex regression covering both the selected weight axis and weight-dependent glyph advances

## Root cause

Variable font providers can return a single typeface whose default variation position is regular weight, even when SVG requests `font-weight="900"`. Svg.Skia previously reused that default instance. In addition, the HarfBuzz bridge reopened the underlying font stream but did not restore the Skia typeface's variation coordinates, so shaping still used the default master even if drawing used a varied face.

For the Geist reproduction attached to #543, the default-master path produced an `EK` advance of about 145.98 px. Applying weight 900 to both Skia and HarfBuzz produces about 158.98 px, matching Chrome's layout and placing the second glyph at the browser position.

## Implementation details

`SkiaModel` now detects the standard OpenType `wght` axis, clamps the requested CSS weight to the font's supported range, preserves every existing variation coordinate, and clones the typeface only when its weight coordinate needs to change. Static fonts and variable fonts without a `wght` axis retain the existing behavior.

The HarfBuzz shaper now copies all resolved Skia variation coordinates into its font before shaping. This keeps layout advances, positioned glyphs, and Skia rasterization on the same font instance.

## Validation

- reproduced the issue with the attached SVG and Geist variable font
- verified the fixed `EK` advance and second-glyph position against Chrome
- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release`
- `dotnet test Svg.Skia.slnx -c Release`
  - 3,110 passed
  - 40 skipped
  - 0 failed

Fixes #543