### PR TITLE
Restore Avalonia CurrentColor and CSS overrides

### DIFF
--- a/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
@@ -200,6 +200,13 @@ public sealed class SvgSource : IDisposable
             return new Uri(System.IO.Path.GetFullPath(path));
         }
 
+        if (path.StartsWith("/", StringComparison.Ordinal) &&
+            baseUri is { IsAbsoluteUri: true } &&
+            !baseUri.IsFile)
+        {
+            return new Uri($"{baseUri.Scheme}://{baseUri.Authority}{path}", UriKind.Absolute);
+        }
+
         if (Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri))
         {
             return absoluteUri;

--- a/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
@@ -212,7 +212,7 @@ public sealed class SvgSource : IDisposable
             baseUri is { IsAbsoluteUri: true } &&
             !baseUri.IsFile)
         {
-            return new Uri($"{baseUri.Scheme}://{baseUri.Authority}{path}", UriKind.Absolute);
+            return new Uri(baseUri, path);
         }
 
         if (Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri))

--- a/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Skia.Avalonia/SvgSource.cs
@@ -200,7 +200,15 @@ public sealed class SvgSource : IDisposable
             return new Uri(System.IO.Path.GetFullPath(path));
         }
 
+        if (path.StartsWith("//", StringComparison.Ordinal) &&
+            baseUri is { IsAbsoluteUri: true } &&
+            !baseUri.IsFile)
+        {
+            return new Uri(baseUri, path);
+        }
+
         if (path.StartsWith("/", StringComparison.Ordinal) &&
+            !path.StartsWith("//", StringComparison.Ordinal) &&
             baseUri is { IsAbsoluteUri: true } &&
             !baseUri.IsFile)
         {

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Assets/Issue545Css.svg
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Assets/Issue545Css.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <rect width="10" height="10" fill="#FF0000" />
+</svg>

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Assets/Issue545CurrentColor.svg
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Assets/Issue545CurrentColor.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <rect width="10" height="10" fill="currentColor" />
+</svg>

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgControlTests.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgControlTests.cs
@@ -11,6 +11,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Svg.Skia;
+using Avalonia.Svg.Skia.UnitTests.Views;
 using Avalonia.Threading;
 using ShimSkiaSharp;
 using ShimSkiaSharp.Editing;
@@ -277,6 +278,43 @@ public class SvgControlTests
         await WaitForSourceChangeAsync(svg, initialPicture);
 
         Assert.Equal(new SKColor(0, 128, 255, 255), GetFirstFillColor(svg.SkSvg));
+    }
+
+    [AvaloniaFact]
+    public async Task XamlPath_AppliesInlineAndStyledRecolorOverrides()
+    {
+        var view = new Issue545RecolorView();
+        var window = new Window
+        {
+            Content = view
+        };
+
+        window.Show();
+        try
+        {
+            await WaitForSourceAsync(view.InlineCurrentColorControl);
+            await WaitForSourceAsync(view.InlineCssControl);
+            await WaitForSourceAsync(view.StyledCurrentColorControl);
+            await WaitForSourceAsync(view.StyledCssControl);
+            await WaitForPendingLoadToClearAsync(view.InlineCurrentColorControl);
+            await WaitForPendingLoadToClearAsync(view.InlineCssControl);
+            await WaitForPendingLoadToClearAsync(view.StyledCurrentColorControl);
+            await WaitForPendingLoadToClearAsync(view.StyledCssControl);
+            var currentColor = new SKColor(0, 128, 255, 255);
+            var cssColor = new SKColor(0, 255, 0, 255);
+            Assert.Equal(Color.FromRgb(0, 128, 255), view.InlineCurrentColorControl.CurrentColor);
+            Assert.Equal("rect { fill: #00FF00; }", Svg.GetCss(view.InlineCssControl));
+            Assert.Equal(Color.FromRgb(0, 128, 255), view.StyledCurrentColorControl.CurrentColor);
+            Assert.Equal("rect { fill: #00FF00; }", Svg.GetCss(view.StyledCssControl));
+            Assert.Equal(currentColor, GetFirstFillColor(view.InlineCurrentColorControl.SkSvg));
+            Assert.Equal(cssColor, GetFirstFillColor(view.InlineCssControl.SkSvg));
+            Assert.Equal(currentColor, GetFirstFillColor(view.StyledCurrentColorControl.SkSvg));
+            Assert.Equal(cssColor, GetFirstFillColor(view.StyledCssControl.SkSvg));
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
@@ -132,6 +132,26 @@ public class SvgSourceTests
     }
 
     [AvaloniaFact]
+    public async Task LoadAsync_RootRelativeResource_AppliesCurrentColor()
+    {
+        var baseUri = new Uri("avares://Svg.Controls.Skia.Avalonia.UnitTests/Views/Issue545RecolorView.axaml");
+        var currentColor = System.Drawing.Color.FromArgb(255, 0, 128, 255);
+        var parameters = new SvgParameters(null, null, currentColor);
+
+        using var source = await SvgSource.LoadAsync(
+            "/Assets/Issue545CurrentColor.svg",
+            baseUri,
+            parameters);
+
+        Assert.NotNull(source.Svg);
+        Assert.Equal(currentColor, source.Parameters?.CurrentColor);
+        var command = source.Svg.Model?
+            .FindCommands<DrawPathCanvasCommand>()
+            .FirstOrDefault(x => x.Paint?.Style == SKPaintStyle.Fill);
+        Assert.Equal(new SKColor(0, 128, 255, 255), command?.Paint?.Color);
+    }
+
+    [AvaloniaFact]
     public async Task ReLoadAsync_PathBackedSource_PreservesPicture()
     {
         var path = CreateTempSvgFile(SampleSvg);
@@ -165,6 +185,16 @@ public class SvgSourceTests
     public void NormalizePath_RelativePath_UsesBaseUri()
     {
         var uri = SvgSource.NormalizePath("Assets/Icon.svg", new Uri("avares://Svg.Controls.Skia.Avalonia.UnitTests/"));
+
+        Assert.Equal("avares://Svg.Controls.Skia.Avalonia.UnitTests/Assets/Icon.svg", uri.ToString());
+    }
+
+    [AvaloniaFact]
+    public void NormalizePath_RootRelativePath_UsesBaseUriAuthority()
+    {
+        var uri = SvgSource.NormalizePath(
+            "/Assets/Icon.svg",
+            new Uri("avares://Svg.Controls.Skia.Avalonia.UnitTests/Views/Sample.axaml"));
 
         Assert.Equal("avares://Svg.Controls.Skia.Avalonia.UnitTests/Assets/Icon.svg", uri.ToString());
     }

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
@@ -200,6 +200,16 @@ public class SvgSourceTests
     }
 
     [AvaloniaFact]
+    public void NormalizePath_SchemeRelativePath_PreservesAuthority()
+    {
+        var uri = SvgSource.NormalizePath(
+            "//cdn.example.com/icon.svg",
+            new Uri("https://app.example.com/Assets/Icon.svg"));
+
+        Assert.Equal("https://cdn.example.com/icon.svg", uri.ToString());
+    }
+
+    [AvaloniaFact]
     public void TypeConverter_String_CreatesPathBackedSourceWithoutEagerLoad()
     {
         var path = CreateTempSvgFile(SampleSvg);

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/SvgSourceTests.cs
@@ -200,6 +200,16 @@ public class SvgSourceTests
     }
 
     [AvaloniaFact]
+    public void NormalizePath_RootRelativePath_PreservesBaseUriUserInfo()
+    {
+        var uri = SvgSource.NormalizePath(
+            "/icon.svg",
+            new Uri("https://user:pass@app.example.com/Assets/Icon.svg"));
+
+        Assert.Equal("https://user:pass@app.example.com/icon.svg", uri.ToString());
+    }
+
+    [AvaloniaFact]
     public void NormalizePath_SchemeRelativePath_PreservesAuthority()
     {
         var uri = SvgSource.NormalizePath(

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Views/Issue545RecolorView.axaml
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Views/Issue545RecolorView.axaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Avalonia.Svg.Skia.UnitTests.Views.Issue545RecolorView">
+  <UserControl.Styles>
+    <Style Selector="Svg.current-color-style">
+      <Setter Property="CurrentColor" Value="#FF0080FF" />
+    </Style>
+    <Style Selector="Svg.css-style">
+      <Setter Property="(Svg.Css)" Value="rect { fill: #00FF00; }" />
+    </Style>
+  </UserControl.Styles>
+
+  <StackPanel>
+    <Svg x:Name="InlineCurrentColor"
+         Width="10"
+         Height="10"
+         Path="/Assets/Issue545CurrentColor.svg"
+         CurrentColor="#FF0080FF" />
+    <Svg x:Name="InlineCss"
+         Width="10"
+         Height="10"
+         Path="/Assets/Issue545Css.svg"
+         Css="rect { fill: #00FF00; }" />
+    <Svg x:Name="StyledCurrentColor"
+         Width="10"
+         Height="10"
+         Path="/Assets/Issue545CurrentColor.svg"
+         Classes="current-color-style" />
+    <Svg x:Name="StyledCss"
+         Width="10"
+         Height="10"
+         Path="/Assets/Issue545Css.svg"
+         Classes="css-style" />
+  </StackPanel>
+</UserControl>

--- a/tests/Svg.Controls.Skia.Avalonia.UnitTests/Views/Issue545RecolorView.axaml.cs
+++ b/tests/Svg.Controls.Skia.Avalonia.UnitTests/Views/Issue545RecolorView.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Avalonia.Svg.Skia.UnitTests.Views;
+
+public partial class Issue545RecolorView : UserControl
+{
+    public Issue545RecolorView()
+    {
+        InitializeComponent();
+    }
+
+    public Svg InlineCurrentColorControl => this.FindControl<Svg>("InlineCurrentColor")!;
+
+    public Svg InlineCssControl => this.FindControl<Svg>("InlineCss")!;
+
+    public Svg StyledCurrentColorControl => this.FindControl<Svg>("StyledCurrentColor")!;
+
+    public Svg StyledCssControl => this.FindControl<Svg>("StyledCss")!;
+}


### PR DESCRIPTION
## Summary

- preserve root-relative Avalonia resources as `avares://` URIs during asynchronous SVG loading
- keep all base URI authority components when resolving paths such as `/Assets/Icon.svg`
- preserve the supplied authority when resolving scheme-relative paths such as `//cdn.example.com/icon.svg`
- add compiled-XAML coverage for inline and style-setter `CurrentColor` and `Css` overrides
- add direct normalization and parameterized async-load regression coverage

## Root cause

The asynchronous Avalonia SVG source pipeline normalized a root-relative resource path with `Uri.TryCreate(..., UriKind.Absolute)`. On .NET, a value such as `/Assets/Icon.svg` became `file:///Assets/Icon.svg` before the `avares://` XAML base URI could be applied. The nonexistent file path produced an unloaded source; the later lazy fallback opened the Avalonia resource without the requested `SvgParameters`, so geometry rendered but `CurrentColor` and CSS overrides were lost.

The initial root-relative fix also treated network-path references beginning with `//` as application-root paths. That replaced the reference's authority with the base URI authority instead of applying standard scheme-relative URI resolution. A later self-review additionally found that manually rebuilding a root-relative URI from `Scheme` and `Authority` omitted base URI user information.

## Fix

When a root-relative path has an absolute non-file base URI, `NormalizePath` now resolves it directly against the base with the standard `Uri` constructor before generic absolute-path detection. For XAML resources this yields `avares://<assembly>/Assets/...`, allowing the async loader to open the resource directly and preserve its color and CSS parameters. Standard resolution also retains every relevant base URI component, including user information.

Scheme-relative references are handled separately through normal `Uri` resolution, preserving their supplied authority while inheriting the base URI scheme.

## Validation

- reproduced and verified the compiled-XAML scenario against Avalonia 12.0.5
- verified the same focused tests with the repository pinned Avalonia dependency
- focused `NormalizePath` tests: 4 passed, 0 failed
- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release` (0 errors)
- `dotnet test Svg.Skia.slnx -c Release` (3,114 passed, 40 skipped, 0 failed)

Fixes #545

Fixes #546
