### PR TITLE
Ensure svg model has no trimmer warnings

### DIFF
--- a/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
+++ b/src/Svg.Controls.Avalonia/Svg.Controls.Avalonia.csproj
@@ -18,6 +18,19 @@
     <PackageTags>svg;vector graphics;rendering;2d;graphics;geometry;shapes;control;avalonia;avaloniaui</PackageTags>
   </PropertyGroup>
 
+  <!-- Trimmer parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <IsTrimmable>true</IsTrimmable>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <!-- AOT parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+  </PropertyGroup>
+
   <Import Project="..\..\build\SourceLink.props" />
   <!--<Import Project="..\..\build\SignAssembly.props" />-->
   <Import Project="..\..\build\ReferenceAssemblies.props" />

--- a/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
@@ -18,6 +18,19 @@
     <PackageTags>svg;vector graphics;rendering;2d;graphics;geometry;shapes;skiasharp;skia;control;avalonia;avaloniaui</PackageTags>
   </PropertyGroup>
 
+  <!-- Trimmer parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <IsTrimmable>true</IsTrimmable>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <!-- AOT parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+  </PropertyGroup>
+
   <Import Project="..\..\build\SourceLink.props" />
   <!--<Import Project="..\..\build\SignAssembly.props" />-->
   <Import Project="..\..\build\ReferenceAssemblies.props" />

--- a/src/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/src/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -17,6 +17,19 @@
     <PackageTags>svg;editor;state;session;avalonia;skia</PackageTags>
   </PropertyGroup>
 
+  <!-- Trimmer parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <IsTrimmable>true</IsTrimmable>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <!-- AOT parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+  </PropertyGroup>
+
   <Import Project="..\..\build\SourceLink.props" />
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />

--- a/src/Svg.Model/Services/SvgGeometryService.cs
+++ b/src/Svg.Model/Services/SvgGeometryService.cs
@@ -194,20 +194,18 @@ internal static class SvgGeometryService
 
         try
         {
-            if (TypeDescriptor.GetConverter(typeof(SvgUnit)).ConvertFromInvariantString(rawValue) is SvgUnit unit)
-            {
-                isAuto = false;
-                isAuthorSpecified = true;
-                return unit;
-            }
+            var unit = SvgUnitConverter.Parse(rawValue.AsSpan().Trim());
+
+            isAuto = false;
+            isAuthorSpecified = true;
+            return unit;
         }
         catch
         {
+            isAuto = false;
+            isAuthorSpecified = element.ContainsAttribute(propertyName);
+            return fallback;
         }
-
-        isAuto = false;
-        isAuthorSpecified = element.ContainsAttribute(propertyName);
-        return fallback;
     }
 
     private static SKPath? CreateRectanglePath(SvgRectangle svgRectangle, SvgFillRule fillRule, SKRect viewport)

--- a/src/Svg.Model/Services/TransformsService.cs
+++ b/src/Svg.Model/Services/TransformsService.cs
@@ -343,26 +343,27 @@ internal static class TransformsService
 
         try
         {
-            if (TypeDescriptor.GetConverter(typeof(SvgUnit)).ConvertFromInvariantString(token) is SvgUnit unit)
-            {
-                value = unit.ToDeviceValue(
-                    isHorizontal ? UnitRenderingType.HorizontalOffset : UnitRenderingType.VerticalOffset,
-                    svgElement,
-                    referenceBox);
-                if (unit.Type != SvgUnitType.Percentage)
-                {
-                    value += isHorizontal ? referenceBox.Left : referenceBox.Top;
-                }
+            var unit = SvgUnitConverter.Parse(token.AsSpan().Trim());
 
-                return true;
+            value = unit.ToDeviceValue(
+                isHorizontal
+                    ? UnitRenderingType.HorizontalOffset
+                    : UnitRenderingType.VerticalOffset,
+                svgElement,
+                referenceBox);
+
+            if (unit.Type != SvgUnitType.Percentage)
+            {
+                value += isHorizontal ? referenceBox.Left : referenceBox.Top;
             }
+
+            return true;
         }
         catch
         {
+            value = 0f;
+            return false;
         }
-
-        value = 0f;
-        return false;
     }
 
     private static bool TryGetTransformOriginKeywordUnit(string token, bool isHorizontal, out SvgUnit unit)

--- a/src/Svg.Model/Svg.Model.csproj
+++ b/src/Svg.Model/Svg.Model.csproj
@@ -16,6 +16,19 @@
     <PackageTags>svg;vector graphics;rendering;2d;graphics;geometry;shapes;skiasharp;skia;model</PackageTags>
   </PropertyGroup>
 
+  <!-- Trimmer parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <IsTrimmable>true</IsTrimmable>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
+  <!-- AOT parameters -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!--<DefineConstants>$(DefineConstants);USE_DEBUG_DRAW_BOUNDS</DefineConstants>-->
     <!--<DefineConstants>$(DefineConstants);USE_DEBUG_DRAW_FILTER_BOUNDS</DefineConstants>-->


### PR DESCRIPTION
Hi, first of all, thank you for this library.

I was running an AOT publish with a reference to `Svg.Controls.Skia.Avalonia 2.0.0.13` which referenced `Svg.Model 5.1.1` and got the following trimmer warnings:

```
    /_/src/Svg.Model/Services/TransformsService.cs(346): Trim analysis warning IL2026: Svg.Model.Services.TransformsService.TryResolveTransformOriginComponent(String,Boolean,SvgElement,SKRect,Single&): Using member 'System.ComponentModel.TypeDescriptor.GetConverter(Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.
    /_/src/Svg.Model/Services/SvgGeometryService.cs(197): Trim analysis warning IL2026: Svg.Model.Services.SvgGeometryService.GetComputedUnit(SvgElement,String,SvgUnit,Boolean,Boolean&,Boolean&,Boolean): Using member 'System.ComponentModel.TypeDescriptor.GetConverter(Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.
```

To fix this, I noticed that other code paths use `SvgUnitConverter.Parse` and decided to use this as a trimmer-safe alternative.

Additionally, I added AOT/Trimmer build properties to the relevant projects to ensure these errors are caught during normal builds in the future.