### PR TITLE
Fix Linux SkiaSharp native asset version mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,9 @@ jobs:
       - name: Pack
         run: dotnet pack Svg.Skia.slnx -c Release --no-restore -p:VersionSuffix="${{ env.VERSION_SUFFIX }}" -o artifacts/packages
 
+      - name: Verify Linux package dependencies
+        run: bash scripts/verify_linux_package_dependencies.sh artifacts/packages
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Pack
         run: dotnet pack Svg.Skia.slnx -c Release --no-restore -o artifacts/packages
 
+      - name: Verify Linux package dependencies
+        run: bash scripts/verify_linux_package_dependencies.sh artifacts/packages
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/verify_linux_package_dependencies.sh
+++ b/scripts/verify_linux_package_dependencies.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+packages_dir="${1:-artifacts/packages}"
+
+if [[ ! -d "$packages_dir" ]]; then
+  echo "Package directory does not exist: $packages_dir" >&2
+  exit 1
+fi
+
+core_package="$(find "$packages_dir" -maxdepth 1 -type f -name 'Svg.Skia.[0-9]*.nupkg' -print -quit)"
+controls_package="$(find "$packages_dir" -maxdepth 1 -type f -name 'Svg.Controls.Skia.Avalonia.[0-9]*.nupkg' -print -quit)"
+
+if [[ -z "$core_package" || -z "$controls_package" ]]; then
+  echo "Svg.Skia and Svg.Controls.Skia.Avalonia packages are required." >&2
+  exit 1
+fi
+
+controls_file="$(basename "$controls_package")"
+controls_version="${controls_file#Svg.Controls.Skia.Avalonia.}"
+controls_version="${controls_version%.nupkg}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+unzip -p "$core_package" Svg.Skia.nuspec > "$work_dir/Svg.Skia.nuspec"
+unzip -p "$controls_package" Svg.Controls.Skia.Avalonia.nuspec > "$work_dir/Svg.Controls.Skia.Avalonia.nuspec"
+
+if grep -q '<dependency id="SkiaSharp.NativeAssets.Linux"' "$work_dir/Svg.Skia.nuspec"; then
+  echo "Svg.Skia must let applications choose their Linux native asset package." >&2
+  exit 1
+fi
+
+managed_version="$(sed -n 's/.*<dependency id="SkiaSharp" version="\([^"]*\)".*/\1/p' "$work_dir/Svg.Skia.nuspec" | sort -u)"
+native_version="$(sed -n 's/.*<dependency id="SkiaSharp.NativeAssets.Linux" version="\([^"]*\)".*/\1/p' "$work_dir/Svg.Controls.Skia.Avalonia.nuspec" | sort -u)"
+
+if [[ -z "$managed_version" || "$managed_version" == *$'\n'* ]]; then
+  echo "Svg.Skia must declare exactly one managed SkiaSharp version." >&2
+  exit 1
+fi
+
+if [[ -z "$native_version" || "$native_version" == *$'\n'* ]]; then
+  echo "Svg.Controls.Skia.Avalonia must declare exactly one Linux native SkiaSharp version." >&2
+  exit 1
+fi
+
+if [[ "$managed_version" != "$native_version" ]]; then
+  echo "Managed SkiaSharp $managed_version does not match Linux native SkiaSharp $native_version." >&2
+  exit 1
+fi
+
+dotnet new console \
+  --name LinuxConsumer \
+  --output "$work_dir/consumer" \
+  --framework net10.0 \
+  --no-restore
+
+dotnet package add "Svg.Controls.Skia.Avalonia@$controls_version" \
+  --project "$work_dir/consumer/LinuxConsumer.csproj" \
+  --no-restore
+
+dotnet restore "$work_dir/consumer/LinuxConsumer.csproj" \
+  --runtime linux-x64 \
+  --source "$packages_dir" \
+  --source https://api.nuget.org/v3/index.json
+
+dotnet publish "$work_dir/consumer/LinuxConsumer.csproj" \
+  --configuration Release \
+  --runtime linux-x64 \
+  --self-contained false \
+  --no-restore \
+  --output "$work_dir/publish"
+
+assets_file="$work_dir/consumer/obj/project.assets.json"
+
+grep -q "\"SkiaSharp/$managed_version\"" "$assets_file"
+grep -q "\"SkiaSharp.NativeAssets.Linux/$native_version\"" "$assets_file"
+
+if [[ ! -f "$work_dir/publish/libSkiaSharp.so" ]]; then
+  echo "The linux-x64 consumer did not publish libSkiaSharp.so." >&2
+  exit 1
+fi
+
+echo "Verified linux-x64 package graph with SkiaSharp $managed_version."

--- a/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
+++ b/src/Svg.Controls.Skia.Avalonia/Svg.Controls.Skia.Avalonia.csproj
@@ -43,6 +43,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Svg.Skia\Svg.Skia.csproj" />
+    <!-- Avalonia.Skia 12 supplies SkiaSharp 3 native assets, while Svg.Skia uses SkiaSharp 4. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Svg.Skia/Svg.Skia.csproj
+++ b/src/Svg.Skia/Svg.Skia.csproj
@@ -50,8 +50,6 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" />
-    <!-- SkiaSharp does not include Linux native assets for desktop target frameworks. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
   </ItemGroup>
 
 </Project>

--- a/src/Svg.Skia/Svg.Skia.csproj
+++ b/src/Svg.Skia/Svg.Skia.csproj
@@ -50,6 +50,8 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" />
+    <!-- SkiaSharp does not include Linux native assets for desktop target frameworks. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- add `SkiaSharp.NativeAssets.Linux` 4.148.0 to `Svg.Controls.Skia.Avalonia`
- keep the standalone `Svg.Skia` package native-neutral, preserving the application choice between `SkiaSharp.NativeAssets.Linux` and `SkiaSharp.NativeAssets.Linux.NoDependencies`
- verify packed NuGet dependency metadata and a clean `linux-x64` consumer publish in build and release workflows

## Root cause

`Svg.Controls.Skia.Avalonia` 12.0.0.14 upgraded `Svg.Skia` to 5.2.0 and managed SkiaSharp to 4.148.0. The SkiaSharp meta-package supplies Windows and macOS native assets, but not Linux. `Avalonia.Skia` therefore remained the only source of `SkiaSharp.NativeAssets.Linux`, at 3.119.4. On Linux, managed 4.148.0 rejected native 3.119.4 during `SkiaApi` initialization.

The Linux native dependency was deliberately removed from the core package in #408 after #406 so standalone consumers could choose the standard native package or the `NoDependencies` variant. This change retains that policy and scopes the matching standard native asset to the Avalonia controls package, whose Avalonia dependency already selects the standard variant.

## Regression coverage

The new package verifier:

- rejects a direct Linux SkiaSharp native dependency in `Svg.Skia`
- requires `Svg.Controls.Skia.Avalonia` to declare the same native version as the core managed SkiaSharp dependency
- restores and publishes a clean `linux-x64` consumer from the packed controls package
- verifies the resolved 4.148.0 package graph and published `libSkiaSharp.so`

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-build --no-restore` — 3,115 passed, 40 skipped
- packed consumer verification — SkiaSharp 4.148.0 managed/native match

Fixes #554