### PR TITLE
Fix Avalonia SVG opacity layers

### DIFF
--- a/src/Svg.Controls.Avalonia/AvaloniaPicture.cs
+++ b/src/Svg.Controls.Avalonia/AvaloniaPicture.cs
@@ -208,8 +208,7 @@ public sealed class AvaloniaPicture : IDisposable
                 }
             case SaveLayerCanvasCommand saveLayerCanvasCommand:
                 {
-                    // TODO: SaveLayerCanvasCommand
-                    commands.Add(new SaveLayerDrawCommand());
+                    commands.Add(new SaveLayerDrawCommand(GetSimpleLayerOpacity(saveLayerCanvasCommand.Paint)));
                     break;
                 }
             case DrawImageCanvasCommand drawImageCanvasCommand:
@@ -342,7 +341,18 @@ public sealed class AvaloniaPicture : IDisposable
                 }
             case SaveLayerDrawCommand saveLayerDrawCommand:
                 {
-                    pushedStates.Push(new Stack<IDisposable>());
+                    var layerStates = new Stack<IDisposable>();
+                    pushedStates.Push(layerStates);
+                    if (saveLayerDrawCommand.Opacity is { } opacity)
+                    {
+                        // SVG opacity composites the layer before applying alpha; prevent Avalonia from
+                        // folding opacity into each draw operation inside the layer.
+                        layerStates.Push(context.PushRenderOptions(new AM.RenderOptions
+                        {
+                            RequiresFullOpacityHandling = true
+                        }));
+                        layerStates.Push(context.PushOpacity(opacity));
+                    }
                     break;
                 }
             case ImageDrawCommand imageDrawCommand:
@@ -411,6 +421,22 @@ public sealed class AvaloniaPicture : IDisposable
         {
             Draw(context, command, pushedStates);
         }
+    }
+
+    private static double? GetSimpleLayerOpacity(SKPaint? paint)
+    {
+        if (paint?.Color is not { } color ||
+            color.Alpha >= byte.MaxValue ||
+            paint.BlendMode != SKBlendMode.SrcOver ||
+            paint.Shader is not null ||
+            paint.ColorFilter is not null ||
+            paint.ImageFilter is not null ||
+            paint.PathEffect is not null)
+        {
+            return null;
+        }
+
+        return color.Alpha / 255d;
     }
 
     public void Dispose()

--- a/src/Svg.Controls.Avalonia/Commands/SaveLayerDrawCommand.cs
+++ b/src/Svg.Controls.Avalonia/Commands/SaveLayerDrawCommand.cs
@@ -4,7 +4,10 @@ namespace Avalonia.Svg.Commands;
 
 public sealed class SaveLayerDrawCommand : DrawCommand
 {
-    public SaveLayerDrawCommand()
+    public double? Opacity { get; }
+
+    public SaveLayerDrawCommand(double? opacity)
     {
+        Opacity = opacity;
     }
 }

--- a/tests/Svg.Controls.Avalonia.UnitTests/Svg.Controls.Avalonia.UnitTests.csproj
+++ b/tests/Svg.Controls.Avalonia.UnitTests/Svg.Controls.Avalonia.UnitTests.csproj
@@ -11,6 +11,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\XUnit.v3.props" />
   <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Skia.props" />
  
   <ItemGroup>
     <AvaloniaResource Include="Assets\*" />

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgOpacityVisualTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgOpacityVisualTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Svg;
+using Xunit;
+
+namespace Avalonia.Svg.UnitTests;
+
+public class SvgOpacityVisualTests
+{
+    [AvaloniaFact]
+    public void SvgImage_AppliesOpacityToIndividualElement()
+    {
+        using var bitmap = RenderSvg("""
+            <svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">
+              <rect x="0" y="0" width="40" height="40" fill="black" opacity="0"/>
+              <rect x="40" y="0" width="40" height="40" fill="black" opacity="0.5"/>
+            </svg>
+            """);
+
+        AssertColor(GetPixel(bitmap, 20, 20), 255, 6);
+        AssertColor(GetPixel(bitmap, 60, 20), 127, 6);
+    }
+
+    [AvaloniaFact]
+    public void SvgImage_CompositesGroupBeforeApplyingOpacity()
+    {
+        using var bitmap = RenderSvg("""
+            <svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">
+              <g opacity="0.5">
+                <rect x="0" y="0" width="60" height="40" fill="black"/>
+                <rect x="20" y="0" width="60" height="40" fill="black"/>
+              </g>
+            </svg>
+            """);
+
+        var single = GetPixel(bitmap, 10, 20);
+        var overlap = GetPixel(bitmap, 40, 20);
+
+        AssertColor(single, 127, 6);
+        AssertColor(overlap, 127, 6);
+    }
+
+    private static WriteableBitmap RenderSvg(string svg)
+    {
+        var source = SvgSource.LoadFromSvg(svg);
+        Assert.NotNull(source.Picture);
+
+        var image = new Image
+        {
+            Source = new SvgImage { Source = source },
+            Width = source.Picture!.CullRect.Width,
+            Height = source.Picture.CullRect.Height,
+            Stretch = Stretch.None
+        };
+
+        var window = new Window
+        {
+            Width = source.Picture.CullRect.Width,
+            Height = source.Picture.CullRect.Height,
+            Background = Brushes.White,
+            Content = image
+        };
+
+        window.Show();
+        var frame = window.CaptureRenderedFrame()
+            ?? throw new InvalidOperationException("No rendered frame was captured.");
+        window.Close();
+        return frame;
+    }
+
+    private static Pixel GetPixel(WriteableBitmap bitmap, int x, int y)
+    {
+        using var framebuffer = bitmap.Lock();
+        var offset = y * framebuffer.RowBytes + x * framebuffer.Format.BitsPerPixel / 8;
+        if (framebuffer.Format == PixelFormat.Bgra8888)
+        {
+            return new Pixel(
+                Marshal.ReadByte(framebuffer.Address, offset + 2),
+                Marshal.ReadByte(framebuffer.Address, offset + 1),
+                Marshal.ReadByte(framebuffer.Address, offset));
+        }
+
+        Assert.Equal(PixelFormat.Rgba8888, framebuffer.Format);
+        return new Pixel(
+            Marshal.ReadByte(framebuffer.Address, offset),
+            Marshal.ReadByte(framebuffer.Address, offset + 1),
+            Marshal.ReadByte(framebuffer.Address, offset + 2));
+    }
+
+    private static void AssertColor(Pixel color, byte expected, byte tolerance)
+    {
+        Assert.InRange(color.Red, expected - tolerance, expected + tolerance);
+        Assert.InRange(color.Green, expected - tolerance, expected + tolerance);
+        Assert.InRange(color.Blue, expected - tolerance, expected + tolerance);
+    }
+
+    private readonly record struct Pixel(byte Red, byte Green, byte Blue);
+}

--- a/tests/Svg.Controls.Avalonia.UnitTests/TestApplication.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/TestApplication.cs
@@ -10,7 +10,11 @@ internal static class SvgControlsAvaloniaTestsAppBuilder
 {
     public static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<SvgControlsAvaloniaTestsApp>()
-            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                UseHeadlessDrawing = false
+            })
             .LogToTrace();
 }
 


### PR DESCRIPTION
## Summary

- preserve alpha-only `SaveLayer` paint when converting SVG commands to native Avalonia draw commands
- force Avalonia's full opacity handling so an SVG element or group is composited before its opacity is applied
- add headless visual regressions for `opacity="0"`, partial element opacity, and overlapping children under group opacity

## Root cause

The SVG scene correctly emitted an opacity `SaveLayer`, and the Skia-backed Avalonia control already rendered that layer correctly. The native `Svg.Controls.Avalonia` adapter converted every `SaveLayerCanvasCommand` into a marker with no paint data, so element opacity was discarded. Simply calling Avalonia `PushOpacity` was also insufficient because its default fast path folds opacity into each draw operation, which makes overlapping children too dark. The adapter now carries alpha-only layer opacity and requests full opacity handling for the scope.

Addresses #550.

## Validation

- `dotnet format Svg.Skia.slnx --no-restore`
- `dotnet build Svg.Skia.slnx -c Release --no-restore`
- `dotnet test Svg.Skia.slnx -c Release --no-build --no-restore`
- focused native Avalonia opacity tests: 13 passed
- focused Skia-backed Avalonia opacity test: 1 passed
- full suite: 3,117 passed, 40 skipped