### PR TITLE
Keep run typeface when character fallback finds nothing

### DIFF
--- a/src/Svg.Skia/SkiaSvgAssetLoader.cs
+++ b/src/Svg.Skia/SkiaSvgAssetLoader.cs
@@ -154,6 +154,19 @@ public partial class SkiaSvgAssetLoader : Model.ISvgAssetLoader, Model.ISvgImage
             else
             {
                 typeface = MatchCharacterForSpan(GetCodepoint(text, i, ch), out var familyOverride);
+                if (typeface is null && runningFont.Typeface is { } resolvedTypeface)
+                {
+                    // No installed font claims this character. That is not a reason to draw it
+                    // with no font at all: clearing the running typeface leaves the font with
+                    // no metrics, so GetTextAdvance below returns 0 for every span and the
+                    // caller, which positions each span by accumulating those advances, paints
+                    // the whole run at one x. Keeping the face already resolved for the run
+                    // preserves its metrics and degrades to a missing-glyph box instead of an
+                    // unreadable pile of glyphs.
+                    typeface = resolvedTypeface;
+                    familyOverride = null;
+                }
+
                 matchedShimTypeface = ToShimTypeface(typeface, requestedWeight, familyOverride);
             }
 

--- a/tests/Svg.Skia.UnitTests/SkiaSvgAssetLoaderCachingTests.cs
+++ b/tests/Svg.Skia.UnitTests/SkiaSvgAssetLoaderCachingTests.cs
@@ -588,6 +588,26 @@ public class SkiaSvgAssetLoaderCachingTests
         AssertDocumentTypefaceNotFamily(assetLoader, childFamily, "S", childExpectedFamily);
     }
 
+    [Fact]
+    public void FindTypefaces_KeepsAdvancesWhenNoFontClaimsTheCharacter()
+    {
+        // A private-use codepoint that no installed font is expected to claim, so character
+        // fallback finds nothing. The span must still carry an advance: the callers position
+        // consecutive spans by accumulating these values, so a zero advance draws every span
+        // of the run at the same x. On a platform whose font manager matches nothing at all -
+        // browser-wasm has a single embedded face and answers no family or character query -
+        // every span of every label took that path and each label rendered as one dense mark.
+        var assetLoader = new SkiaSvgAssetLoader(new SkiaModel(new SKSvgSettings()));
+        var paint = CreateTextPaint(24f);
+
+        var spans = assetLoader.FindTypefaces("A\uE000B", paint);
+
+        Assert.NotEmpty(spans);
+        Assert.All(spans, span => Assert.True(
+            span.Advance > 0f,
+            $"span \"{span.Text}\" reported an advance of {span.Advance}"));
+    }
+
     private static SKPaint CreateTextPaint(float textSize)
     {
         return new SKPaint


### PR DESCRIPTION
Fixes #558.

`SkiaSvgAssetLoader.FindTypefaces` clears the running font's typeface whenever per-character fallback finds no match for a character. A font with no typeface has no metrics, so the `GetTextAdvance` call in `YieldCurrentTypefaceText` returns `0` for every span yielded after that point. `SvgSceneTextCompiler` positions consecutive spans by accumulating exactly those advances (`currentX += typefaceSpan.Advance`), so the whole run is drawn at one `x` and the text renders as a single dense mark.

This keeps the face already resolved for the run when character fallback finds nothing. An unmatched character then degrades to a missing-glyph box, which is what it looked like before the split, instead of collapsing the line.

It is visible on any platform for a codepoint no installed font claims, and total under `browser-wasm`, where one embedded face is the only font and no family or character query matches — there, every label in every document collapsed. Issue #558 has the full derivation and a self-contained WebAssembly reproduction.

## The change

Thirteen lines in `FindTypefaces`:

```csharp
typeface = MatchCharacterForSpan(GetCodepoint(text, i, ch), out var familyOverride);
if (typeface is null && runningFont.Typeface is { } resolvedTypeface)
{
    typeface = resolvedTypeface;
    familyOverride = null;
}
```

`familyOverride` is cleared alongside it so the span is not labelled with a family that was never resolved.

## Test

`SkiaSvgAssetLoaderCachingTests.FindTypefaces_KeepsAdvancesWhenNoFontClaimsTheCharacter` asserts every span carries a non-zero advance for text containing `U+E000`, a private-use codepoint nothing claims.

On `master` it fails on Windows with `span "" reported an advance of 0`; with the change it passes. No browser needed to confirm either way.

## Verification

Per `AGENTS.md`, with submodules initialised:

- `dotnet format Svg.Skia.slnx --no-restore` — clean
- `dotnet build Svg.Skia.slnx -c Release` — 0 errors
- `dotnet test Svg.Skia.slnx -c Release` — all suites pass; `Svg.Skia.UnitTests` 1112 passed / 44 skipped, against 1111 / 44 before, the extra one being the new test
- The WebAssembly reproduction in #558 goes from two of five cases collapsed to none

I have not touched the typeface providers. #558 notes separately that both return null for every family on a single-font platform, which is real but is not what causes this; happy to send that as its own change if you would like it.
