### PR TITLE
Add styled Avalonia SVG source resources

### DIFF
--- a/src/Svg.Controls.Avalonia/SvgImage.cs
+++ b/src/Svg.Controls.Avalonia/SvgImage.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Metadata;
+using Avalonia.Utilities;
 using ShimSkiaSharp;
 using SP = Svg.Model;
 
@@ -13,8 +14,13 @@ namespace Avalonia.Svg;
 /// <summary>
 /// An <see cref="IImage"/> that uses a <see cref="SvgSource"/> for content.
 /// </summary>
-public class SvgImage : AvaloniaObject, IImage
+public class SvgImage : AvaloniaObject, IImage, IWeakEventSubscriber<EventArgs>
 {
+    private static readonly WeakEvent<SvgSource, EventArgs> s_sourceInvalidatedWeakEvent =
+        WeakEvent.Register<SvgSource>(
+            static (source, handler) => source.Invalidated += handler,
+            static (source, handler) => source.Invalidated -= handler);
+
     /// <summary>
     /// Raised when the resource changes visually.
     /// </summary>
@@ -102,8 +108,25 @@ public class SvgImage : AvaloniaObject, IImage
 
         if (change.Property == SourceProperty)
         {
-            // TODO: Invalidate IImage
+            if (change.GetOldValue<SvgSource?>() is { } oldSource)
+            {
+                s_sourceInvalidatedWeakEvent.Unsubscribe(oldSource, this);
+            }
+
+            if (change.GetNewValue<SvgSource?>() is { } newSource)
+            {
+                s_sourceInvalidatedWeakEvent.Subscribe(newSource, this);
+            }
+
             RaiseInvalidated(EventArgs.Empty);
+        }
+    }
+
+    void IWeakEventSubscriber<EventArgs>.OnEvent(object? sender, WeakEvent ev, EventArgs e)
+    {
+        if (ev == s_sourceInvalidatedWeakEvent)
+        {
+            RaiseInvalidated(e);
         }
     }
 

--- a/src/Svg.Controls.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Avalonia/SvgSource.cs
@@ -21,13 +21,15 @@ namespace Avalonia.Svg;
 /// Represents a Svg based image.
 /// </summary>
 [TypeConverter(typeof(SvgSourceTypeConverter))]
-public class SvgSource : MarkupExtension
+public class SvgSource : MarkupExtension, ISupportInitialize
 {
     private static readonly SM.ISvgAssetLoader s_assetLoader = new AvaloniaSvgAssetLoader();
     private Uri? _baseUri;
     private string? _path;
     private string? _css;
     private SKPicture? _picture;
+    private bool _isInitializing;
+    private bool _isDirty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SvgSource"/> class.
@@ -74,7 +76,7 @@ public class SvgSource : MarkupExtension
             }
 
             _path = value;
-            Reload();
+            QueueReload();
         }
     }
 
@@ -92,7 +94,7 @@ public class SvgSource : MarkupExtension
             }
 
             _css = value;
-            Reload();
+            QueueReload();
         }
     }
 
@@ -120,6 +122,19 @@ public class SvgSource : MarkupExtension
         _baseUri ??= serviceProvider.GetContextBaseUri();
         Reload();
         return this;
+    }
+
+    /// <inheritdoc/>
+    public void BeginInit()
+    {
+        _isInitializing = true;
+    }
+
+    /// <inheritdoc/>
+    public void EndInit()
+    {
+        _isInitializing = false;
+        Reload();
     }
 
     /// <summary>
@@ -266,9 +281,15 @@ public class SvgSource : MarkupExtension
 
     private void Reload()
     {
+        if (!_isDirty)
+        {
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(_path))
         {
             Picture = null;
+            _isDirty = false;
             return;
         }
 
@@ -285,5 +306,15 @@ public class SvgSource : MarkupExtension
         }
 
         Picture = LoadPicture(_path, _baseUri, new SvgParameters(null, _css));
+        _isDirty = false;
+    }
+
+    private void QueueReload()
+    {
+        _isDirty = true;
+        if (!_isInitializing)
+        {
+            Reload();
+        }
     }
 }

--- a/src/Svg.Controls.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Avalonia/SvgSource.cs
@@ -27,6 +27,7 @@ public class SvgSource : MarkupExtension, ISupportInitialize
     private Uri? _baseUri;
     private string? _path;
     private string? _css;
+    private SvgParameters? _parameters;
     private SKPicture? _picture;
     private bool _isInitializing;
     private bool _isDirty;
@@ -200,7 +201,13 @@ public class SvgSource : MarkupExtension, ISupportInitialize
     /// <returns>The svg source.</returns>
     public static SvgSource Load(string path, Uri? baseUri, SvgParameters? parameters = null)
     {
-        return new() { Picture = LoadPicture(path, baseUri, parameters) };
+        return new SvgSource(baseUri)
+        {
+            _path = path,
+            _css = parameters?.Css,
+            _parameters = parameters,
+            _picture = LoadPicture(path, baseUri, parameters)
+        };
     }
 
     /// <summary>
@@ -275,6 +282,7 @@ public class SvgSource : MarkupExtension, ISupportInitialize
         {
             _path = _path,
             _css = _css,
+            _parameters = _parameters,
             _picture = Picture?.DeepClone()
         };
     }
@@ -305,7 +313,10 @@ public class SvgSource : MarkupExtension, ISupportInitialize
             }
         }
 
-        Picture = LoadPicture(_path, _baseUri, new SvgParameters(null, _css));
+        var parameters = _parameters is { } existingParameters
+            ? existingParameters with { Css = _css }
+            : new SvgParameters(null, _css);
+        Picture = LoadPicture(_path, _baseUri, parameters);
         _isDirty = false;
     }
 

--- a/src/Svg.Controls.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Avalonia/SvgSource.cs
@@ -5,6 +5,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using Avalonia.Markup.Xaml;
+using Avalonia.Metadata;
 using Avalonia.Platform;
 using ShimSkiaSharp;
 using Svg;
@@ -22,8 +24,74 @@ namespace Avalonia.Svg;
 public class SvgSource
 {
     private static readonly SM.ISvgAssetLoader s_assetLoader = new AvaloniaSvgAssetLoader();
+    private readonly Uri? _baseUri;
+    private string? _path;
+    private string? _css;
+    private SKPicture? _picture;
 
-    public SKPicture? Picture { get; set; }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgSource"/> class.
+    /// </summary>
+    /// <param name="baseUri">The base URL used to resolve relative SVG paths.</param>
+    public SvgSource(Uri? baseUri = null)
+    {
+        _baseUri = baseUri;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgSource"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The XAML service provider.</param>
+    public SvgSource(IServiceProvider serviceProvider)
+        : this(serviceProvider.GetContextBaseUri())
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the SVG resource or file path.
+    /// </summary>
+    [Content]
+    public string? Path
+    {
+        get => _path;
+        set
+        {
+            if (string.Equals(_path, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _path = value;
+            Reload();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the CSS applied when loading <see cref="Path"/>.
+    /// </summary>
+    public string? Css
+    {
+        get => _css;
+        set
+        {
+            if (string.Equals(_css, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _css = value;
+            Reload();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the loaded SVG picture.
+    /// </summary>
+    public SKPicture? Picture
+    {
+        get => _picture;
+        set => _picture = value;
+    }
 
     /// <summary>
     /// Loads svg picture from file or resource.
@@ -159,9 +227,18 @@ public class SvgSource
     /// <returns>A new <see cref="SvgSource"/> instance.</returns>
     public SvgSource Clone()
     {
-        return new SvgSource
+        return new SvgSource(_baseUri)
         {
-            Picture = Picture?.DeepClone()
+            _path = _path,
+            _css = _css,
+            _picture = Picture?.DeepClone()
         };
+    }
+
+    private void Reload()
+    {
+        Picture = string.IsNullOrWhiteSpace(_path)
+            ? null
+            : LoadPicture(_path, _baseUri, new SvgParameters(null, _css));
     }
 }

--- a/src/Svg.Controls.Avalonia/SvgSource.cs
+++ b/src/Svg.Controls.Avalonia/SvgSource.cs
@@ -21,10 +21,10 @@ namespace Avalonia.Svg;
 /// Represents a Svg based image.
 /// </summary>
 [TypeConverter(typeof(SvgSourceTypeConverter))]
-public class SvgSource
+public class SvgSource : MarkupExtension
 {
     private static readonly SM.ISvgAssetLoader s_assetLoader = new AvaloniaSvgAssetLoader();
-    private readonly Uri? _baseUri;
+    private Uri? _baseUri;
     private string? _path;
     private string? _css;
     private SKPicture? _picture;
@@ -32,8 +32,15 @@ public class SvgSource
     /// <summary>
     /// Initializes a new instance of the <see cref="SvgSource"/> class.
     /// </summary>
+    public SvgSource()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgSource"/> class.
+    /// </summary>
     /// <param name="baseUri">The base URL used to resolve relative SVG paths.</param>
-    public SvgSource(Uri? baseUri = null)
+    public SvgSource(Uri? baseUri)
     {
         _baseUri = baseUri;
     }
@@ -46,6 +53,11 @@ public class SvgSource
         : this(serviceProvider.GetContextBaseUri())
     {
     }
+
+    /// <summary>
+    /// Raised when the loaded picture changes.
+    /// </summary>
+    public event EventHandler? Invalidated;
 
     /// <summary>
     /// Gets or sets the SVG resource or file path.
@@ -90,7 +102,24 @@ public class SvgSource
     public SKPicture? Picture
     {
         get => _picture;
-        set => _picture = value;
+        set
+        {
+            if (ReferenceEquals(_picture, value))
+            {
+                return;
+            }
+
+            _picture = value;
+            Invalidated?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        _baseUri ??= serviceProvider.GetContextBaseUri();
+        Reload();
+        return this;
     }
 
     /// <summary>
@@ -237,8 +266,24 @@ public class SvgSource
 
     private void Reload()
     {
-        Picture = string.IsNullOrWhiteSpace(_path)
-            ? null
-            : LoadPicture(_path, _baseUri, new SvgParameters(null, _css));
+        if (string.IsNullOrWhiteSpace(_path))
+        {
+            Picture = null;
+            return;
+        }
+
+        if (_baseUri is null && !File.Exists(_path))
+        {
+            var uri = _path.StartsWith("/")
+                ? new Uri(_path, UriKind.Relative)
+                : new Uri(_path, UriKind.RelativeOrAbsolute);
+            if (!uri.IsAbsoluteUri)
+            {
+                Picture = null;
+                return;
+            }
+        }
+
+        Picture = LoadPicture(_path, _baseUri, new SvgParameters(null, _css));
     }
 }

--- a/src/Svg.Controls.Avalonia/SvgSourceTypeConverter.cs
+++ b/src/Svg.Controls.Avalonia/SvgSourceTypeConverter.cs
@@ -23,6 +23,6 @@ public class SvgSourceTypeConverter : TypeConverter
     {
         var path = (string)value;
         var baseUri = context?.GetContextBaseUri();
-        return SvgSource.Load(path, baseUri);
+        return new SvgSource(baseUri) { Path = path };
     }
 }

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
@@ -13,6 +13,11 @@ namespace Avalonia.Svg.UnitTests;
 
 public class SvgSourceTests
 {
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
     private const string SampleSvg = "<svg width=\"10\" height=\"10\"><rect x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"red\" /></svg>";
     private const string ClipPathSvg = """
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -46,6 +51,29 @@ public class SvgSourceTests
     public void Exposes_Parameterless_Constructor()
     {
         Assert.NotNull(typeof(SvgSource).GetConstructor(Type.EmptyTypes));
+    }
+
+    [AvaloniaFact]
+    public void Initialization_Batches_Path_And_Css_Reload()
+    {
+        var source = new SvgSource(new Uri("avares://Svg.Controls.Avalonia.UnitTests/"));
+        var invalidated = 0;
+        source.Invalidated += (_, _) => invalidated++;
+
+        source.BeginInit();
+        source.Path = "/Assets/Icon.svg";
+        source.Css = "#background { fill: #010203; }";
+
+        Assert.Null(source.Picture);
+        Assert.Equal(0, invalidated);
+
+        source.EndInit();
+
+        Assert.NotNull(source.Picture);
+        Assert.Equal(1, invalidated);
+
+        Assert.Same(source, source.ProvideValue(new EmptyServiceProvider()));
+        Assert.Equal(1, invalidated);
     }
 
     [AvaloniaFact]

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Avalonia;
 using Avalonia.Headless.XUnit;
@@ -40,6 +41,12 @@ public class SvgSourceTests
           <text x="10" y="110" fill="black" font-family="DefaultFont" font-size="100">A</text>
         </svg>
         """;
+
+    [AvaloniaFact]
+    public void Exposes_Parameterless_Constructor()
+    {
+        Assert.NotNull(typeof(SvgSource).GetConstructor(Type.EmptyTypes));
+    }
 
     [AvaloniaFact]
     public void RebuildFromModel_RefreshesPicture()
@@ -95,6 +102,25 @@ public class SvgSourceTests
 
         Assert.Equal("/Assets/Icon.svg", source.Path);
         Assert.NotNull(source.Picture);
+    }
+
+    [AvaloniaFact]
+    public void Css_Reload_Invalidates_Consuming_Image()
+    {
+        var view = new StyledSvgSourceView();
+        var source = Assert.IsType<SvgSource>(view.Resources["StyledIcon"]);
+        var image = new SvgImage { Source = source };
+        var invalidated = 0;
+        image.Invalidated += (_, _) => invalidated++;
+
+        source.Css = "#background { fill: #040506; }";
+
+        var background = source.Picture?
+            .FindCommands<DrawPathCanvasCommand>()
+            .FirstOrDefault();
+        Assert.Equal(1, invalidated);
+        Assert.NotNull(background?.Paint);
+        Assert.Equal(new SKColor(4, 5, 6, 255), background!.Paint!.Color);
     }
 
     [AvaloniaFact]

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
@@ -152,6 +152,23 @@ public class SvgSourceTests
     }
 
     [AvaloniaFact]
+    public void Load_Path_Preserves_Source_For_Css_Reload()
+    {
+        var source = SvgSource.Load(
+            "/Assets/Icon.svg",
+            new Uri("avares://Svg.Controls.Avalonia.UnitTests/"));
+
+        source.Css = "#background { fill: #070809; }";
+
+        var background = source.Picture?
+            .FindCommands<DrawPathCanvasCommand>()
+            .FirstOrDefault();
+        Assert.Equal("/Assets/Icon.svg", source.Path);
+        Assert.NotNull(background?.Paint);
+        Assert.Equal(new SKColor(7, 8, 9, 255), background!.Paint!.Color);
+    }
+
+    [AvaloniaFact]
     public void LoadFromSvg_UsesSvgGlyphPaths()
     {
         var source = SvgSource.LoadFromSvg(SvgFontGlyphSvg);

--- a/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/SvgSourceTests.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Headless.XUnit;
 using Avalonia.Svg;
 using Avalonia.Svg.Commands;
+using Avalonia.Svg.UnitTests.Views;
 using ShimSkiaSharp;
 using ShimSkiaSharp.Editing;
 using Xunit;
@@ -69,6 +70,31 @@ public class SvgSourceTests
 
         Assert.NotSame(source, clone);
         Assert.NotSame(source.Picture, clone.Picture);
+    }
+
+    [AvaloniaFact]
+    public void Xaml_Resource_Loads_Path_With_Css()
+    {
+        var view = new StyledSvgSourceView();
+        var source = Assert.IsType<SvgSource>(view.Resources["StyledIcon"]);
+        var background = source.Picture?
+            .FindCommands<DrawPathCanvasCommand>()
+            .FirstOrDefault();
+
+        Assert.Equal("/Assets/Icon.svg", source.Path);
+        Assert.Equal("#background { fill: #010203; }", source.Css);
+        Assert.NotNull(background?.Paint);
+        Assert.Equal(new SKColor(1, 2, 3, 255), background!.Paint!.Color);
+    }
+
+    [AvaloniaFact]
+    public void Xaml_Resource_Uses_Path_As_Content()
+    {
+        var view = new StyledSvgSourceView();
+        var source = Assert.IsType<SvgSource>(view.Resources["ContentIcon"]);
+
+        Assert.Equal("/Assets/Icon.svg", source.Path);
+        Assert.NotNull(source.Picture);
     }
 
     [AvaloniaFact]

--- a/tests/Svg.Controls.Avalonia.UnitTests/Views/StyledSvgSourceView.axaml
+++ b/tests/Svg.Controls.Avalonia.UnitTests/Views/StyledSvgSourceView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:svg="clr-namespace:Avalonia.Svg;assembly=Svg.Controls.Avalonia"
+             x:Class="Avalonia.Svg.UnitTests.Views.StyledSvgSourceView">
+  <UserControl.Resources>
+    <svg:SvgSource x:Key="StyledIcon"
+                   Path="/Assets/Icon.svg"
+                   Css="#background { fill: #010203; }" />
+    <svg:SvgSource x:Key="ContentIcon">/Assets/Icon.svg</svg:SvgSource>
+  </UserControl.Resources>
+</UserControl>

--- a/tests/Svg.Controls.Avalonia.UnitTests/Views/StyledSvgSourceView.axaml.cs
+++ b/tests/Svg.Controls.Avalonia.UnitTests/Views/StyledSvgSourceView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Svg.UnitTests.Views;
+
+public partial class StyledSvgSourceView : UserControl
+{
+    public StyledSvgSourceView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary

- add XAML-aware Path and Css properties to Avalonia.Svg.SvgSource
- resolve relative SVG resource paths from the XAML service-provider base URI
- preserve content-string conversion and clone the resource contract
- cover explicit path-plus-CSS and content syntax with compiled XAML tests

## Validation

- dotnet format Svg.Skia.slnx --no-restore
- dotnet build Svg.Skia.slnx -c Release --no-restore
- dotnet test Svg.Skia.slnx -c Release --no-build --no-restore