### PR TITLE
Add net10.0 target to MAUI controls

### DIFF
--- a/src/Svg.Controls.Skia.Maui/Svg.Controls.Skia.Maui.csproj
+++ b/src/Svg.Controls.Skia.Maui/Svg.Controls.Skia.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

- add a plain net10.0 target to Svg.Controls.Skia.Maui
- allow non-platform .NET 10 projects, including test projects, to reference the package
- retain the existing Android, iOS, and Mac Catalyst targets

Closes #557

## Validation

- dotnet format Svg.Skia.slnx --no-restore
- dotnet build src/Svg.Controls.Skia.Maui/Svg.Controls.Skia.Maui.csproj -c Release -p:TargetFrameworks=net10.0
- packed the net10.0 target and verified lib/net10.0/Svg.Controls.Skia.Maui.dll
- built a standalone net10.0 consumer against the generated package (0 warnings, 0 errors)
- dotnet build Svg.Skia.slnx -c Release
- dotnet test Svg.Skia.slnx -c Release --no-build (3,117 passed, 40 skipped)

The iOS, Mac Catalyst, and new plain net10.0 targets also built in the direct multi-target build. The Android leg could not run locally because this machine has no Android SDK configured (XA5300).